### PR TITLE
Doesn't work with rbx

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -2,7 +2,7 @@ require 'heroku/helpers'
 require 'heroku/plugin'
 require 'heroku/commands/base'
 
-Dir["#{File.dirname(__FILE__)}/commands/*"].each { |c| require c }
+Dir["#{File.dirname(__FILE__)}/commands/*.rb"].each { |c| require c }
 
 module Heroku
   module Command


### PR DESCRIPTION
Since we do Dir["#{File.dirname(**FILE**)}/commands/*"].each { |c| require c }, it'll load all the files including the *.rbc files generated by rbx. We should limit this to *.rb, unless we plan to load other file extensions.
