### PR TITLE
Bump rest-client to allow >= 1.4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :test do
   gem "webmock", "~> 1.2.2"
 end
 
-gem "rest-client", "~> 1.4.0", :require => "rest_client"
+gem "rest-client", ">= 1.4.0", :require => "rest_client"
 gem "launchy",     "~> 0.3.2"
 gem "json_pure",   ">= 1.2.0", "< 1.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ DEPENDENCIES
   launchy (~> 0.3.2)
   parka (>= 0.5.0)
   rake
-  rest-client (~> 1.4.0)
+  rest-client (>= 1.4.0)
   rspec (~> 1.2.0)
   taps (~> 0.3.11)
   webmock (~> 1.2.2)


### PR DESCRIPTION
I am trying to use this library on an app that need rest-client 1.6.x. Both this and the "taps" dependency of this library need 1.4.x. This patch changes this library to allow >= 1.4 so both versions of rest-client can be used. I have already submitted a similar patch to taps[1].

In addition I have verified this library passes all tests when using rest-client 1.6.x by having my fork explicitly use my custom version of taps with rest-client upgraded[2].

Also to note that someone has already submitted this request[3]. I am just making the patch to make it happen. So once this is applied you can close that request also.
1. http://github.com/ricardochimal/taps/pull/49
2. http://github.com/eric1234/heroku/commit/5b02b2338e1507297dbc644120613165524111b1
3. http://github.com/heroku/heroku/issues#issue/21
