### PR TITLE
"comparison of String with 1 failed (ArgumentError)" when running 'heroku dynos x'

### DIFF
--- a/lib/heroku/commands/app.rb
+++ b/lib/heroku/commands/app.rb
@@ -179,7 +179,7 @@ module Heroku::Command
       app = extract_app
       if dynos = args.shift
         current = heroku.set_dynos(app, dynos)
-        display "#{app} now running on #{current} dyno#{'s' if current > 1}"
+        display "#{app} now running on #{current} dyno#{'s' if current.to_i > 1}"
       else
         info = heroku.info(app)
         display "#{app} is running on #{info[:dynos]} dyno#{'s' if info[:dynos].to_i > 1}"
@@ -190,7 +190,7 @@ module Heroku::Command
       app = extract_app
       if workers = args.shift
         current = heroku.set_workers(app, workers)
-        display "#{app} now running #{current} worker#{'s' if current != 1}"
+        display "#{app} now running #{current} worker#{'s' if current.to_i != 1}"
       else
         info = heroku.info(app)
         display "#{app} is running #{info[:workers]} worker#{'s' if info[:workers].to_i != 1}"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -128,6 +128,11 @@ describe Heroku::Client do
     @client.set_dynos('myapp', 3)
   end
 
+  it "set_workers(app_name, qty) -> scales the workers" do
+    stub_api_request(:put, "/apps/myapp/workers").with(:body => "workers=2")
+    @client.set_workers('myapp', 2)
+  end
+
   it "rake catches 502s and shows the app crashlog" do
     e = RestClient::RequestFailed.new
     e.stub!(:http_code).and_return(502)

--- a/spec/commands/app_spec.rb
+++ b/spec/commands/app_spec.rb
@@ -96,12 +96,103 @@ module Heroku::Command
       @cli.restart
     end
 
-    it "scales dynos" do
-      @cli.stub!(:args).and_return(['+4'])
-      @cli.heroku.should_receive(:set_dynos).with('myapp', '+4').and_return(7)
-      @cli.dynos
+    describe "dynos command" do
+      describe "get dynos count" do
+        before { @cli.stub!(:args).and_return([]) }
+
+        it "with dynos count == 0" do
+          @cli.stub!(:args).and_return([])
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :dynos => '0' })
+          @cli.should_receive(:display).with("myapp is running on 0 dyno")
+          @cli.dynos
+        end
+
+        it "with dynos count == 1" do
+          @cli.stub!(:args).and_return([])
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :dynos => '1' })
+          @cli.should_receive(:display).with("myapp is running on 1 dyno")
+          @cli.dynos
+        end
+
+        it "with dynos count > 1" do
+          @cli.stub!(:args).and_return([])
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :dynos => '3' })
+          @cli.should_receive(:display).with("myapp is running on 3 dynos")
+          @cli.dynos
+        end
+      end
+
+      describe "scales dynos" do
+        it "with dynos count (after update) == 0" do
+          @cli.stub!(:args).and_return(['-2'])
+          @cli.heroku.should_receive(:set_dynos).with('myapp', '-2').and_return('0')
+          @cli.should_receive(:display).with("myapp now running on 0 dyno")
+          @cli.dynos
+        end
+
+        it "with dynos count (after update) == 1" do
+          @cli.stub!(:args).and_return(['-1'])
+          @cli.heroku.should_receive(:set_dynos).with('myapp', '-1').and_return('1')
+          @cli.should_receive(:display).with("myapp now running on 1 dyno")
+          @cli.dynos
+        end
+
+        it "with dynos count (after update) > 1" do
+          @cli.stub!(:args).and_return(['+2'])
+          @cli.heroku.should_receive(:set_dynos).with('myapp', '+2').and_return('4')
+          @cli.should_receive(:display).with("myapp now running on 4 dynos")
+          @cli.dynos
+        end
+      end
     end
 
+    describe "workers command" do
+      describe "get workers count" do
+        before { @cli.stub!(:args).and_return([]) }
+        
+        it "with workers count == 0" do
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :workers => '0' })
+          @cli.should_receive(:display).with("myapp is running 0 workers")
+          @cli.workers
+        end
+        
+        it "with workers count == 1" do
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :workers => '1' })
+          @cli.should_receive(:display).with("myapp is running 1 worker")
+          @cli.workers
+        end
+        
+        it "with workers count > 1" do
+          @cli.heroku.should_receive(:info).with('myapp').and_return({ :workers => '3' })
+          @cli.should_receive(:display).with("myapp is running 3 workers")
+          @cli.workers
+        end
+      end
+      
+      describe "scales workers" do
+        it "with workers count (after update) == 0" do
+          @cli.stub!(:args).and_return(['-2'])
+          @cli.heroku.should_receive(:set_workers).with('myapp', '-2').and_return('0')
+          @cli.should_receive(:display).with("myapp now running 0 workers")
+          @cli.workers
+        end
+        
+        it "with workers count (after update) == 1" do
+          @cli.stub!(:args).and_return(['-1'])
+          @cli.heroku.should_receive(:set_workers).with('myapp', '-1').and_return('1')
+          @cli.should_receive(:display).with("myapp now running 1 worker")
+          @cli.workers
+        end
+        
+        it "with workers count (after update) > 1" do
+          @cli.stub!(:args).and_return(['+2'])
+          @cli.heroku.should_receive(:set_workers).with('myapp', '+2').and_return('4')
+          @cli.should_receive(:display).with("myapp now running 4 workers")
+          @cli.workers
+        end
+      end
+    end
+    
     it "destroys the app specified with --app if user confirms" do
       @cli.stub!(:ask).and_return('y')
       @cli.stub!(:args).and_return(['--app', 'myapp'])


### PR DESCRIPTION
I fixed that error that was occurring only when actually using the command line because in the specs Heroku::Client#set_dynos was stubbed to return a Fixnum when the real implementation is returning a String.
