### PR TITLE
Specify git branch

### DIFF
--- a/lib/heroku/plugin.rb
+++ b/lib/heroku/plugin.rb
@@ -47,7 +47,7 @@ module Heroku
       FileUtils.mkdir_p(path)
       Dir.chdir(path) do
         system("git init -q")
-        if !system("git pull #{uri} -q")
+        if !system("git pull #{uri} master -q")
           FileUtils.rm_rf path
           return false
         end


### PR DESCRIPTION
I was getting a "Could not install xxx. Please check the URL and try again" error when installing any Heroku plugins.  I believe it was due to not having specified a default branch in my git configuration.  This fix makes the heroku gem more specific and not dependent upon the user's git config.
