### PR TITLE
Taps gem dependency

### DIFF
--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client", ">= 1.4.0", "< 1.7.0"
   gem.add_dependency "launchy",     "~> 0.3.2"
   gem.add_dependency "json_pure",   ">= 1.2.0", "< 1.5.0"
+  gem.add_dependency "taps",        "~> 0.3.13"
 end

--- a/lib/heroku/commands/db.rb
+++ b/lib/heroku/commands/db.rb
@@ -166,13 +166,7 @@ module Heroku::Command
     def load_taps
       require 'taps/operation'
       require 'taps/cli'
-      error "The heroku gem requires taps 0.3" unless Taps.version =~ /^0.3/
       display "Loaded Taps v#{Taps.version}"
-    rescue LoadError
-      message  = "Taps 0.3 Load Error: #{$!.message}\n"
-      message << "You may need to install or update the taps gem to use db commands.\n"
-      message << "On most systems this will be:\n\nsudo gem install taps"
-      error message
     end
   end
 end


### PR DESCRIPTION
I was trying to do `heroku db:pull` earlier today, and I noticed the error message:

<pre>Taps 0.3 Load Error: no such file to load -- taps/operation
You may need to install or update the taps gem to use db commands.
On most systems this will be:

sudo gem install taps</pre>


If taps is an actual dependency, it'd make sense to depend on it, and to require a version that's compatible.

This commit does that, and removes the begin/rescue logic around requiring taps. The only downside I can see here is that taps has a number of dependencies, ie sinatra, sequel, etc.
