### PR TITLE
pgbackups:restore bugfix

### DIFF
--- a/lib/heroku/commands/pgbackups.rb
+++ b/lib/heroku/commands/pgbackups.rb
@@ -183,6 +183,8 @@ module Heroku::Command
         "upload"    => "Storing",
         "download"  => "Retreiving",
         "restore"   => "Restoring",
+        "gunzip"    => "Uncompressing",
+        "load"      => "Restoring",
       }
 
       if !transfer["log"]
@@ -205,7 +207,7 @@ module Heroku::Command
           end
 
           # store progress, last one in the logs will get displayed
-          step = step_map[step] or step
+          step = step_map[step] || step
           @last_progress = [step, amount]
         end
 


### PR DESCRIPTION
Got a couple bug reports about broken imports of .sql.gz formatted backups.

I'd like to get this in a new point release of the gem to send back to users
