### PR TITLE
Missing requirement in lib/commands/tail.rb

### DIFF
--- a/lib/heroku/commands/tail.rb
+++ b/lib/heroku/commands/tail.rb
@@ -1,3 +1,5 @@
+require 'heroku/commands/logs'
+
 module Heroku::Command
   class Tail < Logs
     def index


### PR DESCRIPTION
`$ heroku` fails on 1.17.12 with
    /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/lib/heroku/commands/tail.rb:2:in `<module:Command>': uninitialized constant Heroku::Command::Logs (NameError)
        from /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/lib/heroku/commands/tail.rb:1:in`<top (required)>'
        from internal:lib/rubygems/custom_require:29:in `require'
        from <internal:lib/rubygems/custom_require>:29:in`require'
        from /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/lib/heroku/command.rb:5:in `block in <top (required)>'
        from /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/lib/heroku/command.rb:5:in`each'
        from /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/lib/heroku/command.rb:5:in `<top (required)>'
        from <internal:lib/rubygems/custom_require>:29:in`require'
        from internal:lib/rubygems/custom_require:29:in `require'
        from /usr/local/lib/ruby/gems/1.9.1/gems/heroku-1.17.12/bin/heroku:7:in`<top (required)>'
        from /usr/local/bin/heroku:19:in `load'
        from /usr/local/bin/heroku:19:in`<main>'

Just missing a `require 'heroku/commands/logs'` in lib/commands/tail.rb.
