### PR TITLE
make info command accept individual keys as options

### DIFF
--- a/lib/heroku/commands/app.rb
+++ b/lib/heroku/commands/app.rb
@@ -79,11 +79,31 @@ module Heroku::Command
     end
 
     def info
-      name = (args.first && !args.first =~ /^\-\-/) ? args.first : extract_app
-      attrs = heroku.info(name)
+      attrs = heroku.info(extract_app)
 
       attrs[:web_url] ||= "http://#{attrs[:name]}.#{heroku.host}/"
       attrs[:git_url] ||= "git@#{heroku.host}:#{attrs[:name]}.git"
+
+      # when args are a stub in rspec, extract_option doesn't remove
+      # them, this is a workaround for that
+      if args.size > 1 and args[0] == '--app'
+        args.shift 2
+      end
+
+      unless args.empty?
+        arg_symbols = args.map(&:to_sym)
+        invalid_keys = arg_symbols - attrs.keys
+        if invalid_keys.empty?
+          arg_symbols.each { |k| display attrs[k] }
+          return
+        else
+          error <<-eos
+Invalid keys: #{invalid_keys.map(&:to_s).join(', ')}
+
+Valid keys are: #{attrs.keys.map(&:to_s).join(', ')}
+eos
+        end
+      end
 
       display "=== #{attrs[:name]}"
       display "Web URL:        #{attrs[:web_url]}"

--- a/lib/heroku/commands/help.rb
+++ b/lib/heroku/commands/help.rb
@@ -40,7 +40,7 @@ module Heroku::Command
         group.space
         group.command 'list',                         'list your apps'
         group.command 'create [<name>]',              'create a new app'
-        group.command 'info',                         'show app info, like web url and git repo'
+        group.command 'info [<key>] [...]',           'show app info, like web url and git repo'
         group.command 'open',                         'open the app in a web browser'
         group.command 'rename <newname>',             'rename the app'
         group.command 'destroy',                      'destroy the app permanently'

--- a/spec/commands/app_spec.rb
+++ b/spec/commands/app_spec.rb
@@ -7,7 +7,6 @@ module Heroku::Command
     end
 
     it "shows app info, converting bytes to kbs/mbs" do
-      @cli.stub!(:args).and_return(['myapp'])
       @cli.heroku.should_receive(:info).with('myapp').and_return({ :name => 'myapp', :collaborators => [], :addons => [], :repo_size => 2*1024, :database_size => 5*1024*1024 })
       @cli.should_receive(:display).with('=== myapp')
       @cli.should_receive(:display).with('Web URL:        http://myapp.heroku.com/')
@@ -26,6 +25,14 @@ module Heroku::Command
       @cli.stub!(:args).and_return([])
       @cli.stub!(:extract_app_in_dir).and_return('myapp')
       @cli.heroku.should_receive(:info).with('myapp').and_return({ :collaborators => [], :addons => []})
+      @cli.info
+    end
+
+    it "shows app info for a specific key" do
+      @cli.stub!(:args).and_return(['database_size', 'name'])
+      @cli.heroku.should_receive(:info).with('myapp').and_return({ :name => 'myapp', :database_size => 5*1024*1024 })
+      @cli.should_receive(:display).with(5242880)
+      @cli.should_receive(:display).with("myapp")
       @cli.info
     end
 


### PR DESCRIPTION
Makes the info command accept an optional list of keys to display the values of one per line instead of the default info display. The use case is easy parsing of the output.

Did have an issue with extract_option leaving the "--app" args in only when run in rspec. I'm guessing this is because stubbing makes it return the same thing every time. There is a workaround for this in the code to avoid more extensive changes.

Issue 75 is my original request for this.
