### PR TITLE
Parse error from HTML response

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -123,7 +123,7 @@ module Heroku
     end
 
     def self.extract_error(body)
-      msg = parse_error_xml(body) || parse_error_json(body) || parse_error_plain(body) || 'Internal server error'
+      msg = parse_error_xml(body) || parse_error_json(body) || parse_error_plain(body) || parse_error_html(body) || 'Internal server error'
       msg.split("\n").map { |line| ' !   ' + line }.join("\n")
     end
 
@@ -142,6 +142,11 @@ module Heroku
     def self.parse_error_plain(body)
       return unless body.respond_to?(:headers) && body.headers[:content_type].to_s.include?("text/plain")
       body.to_s
+    end
+
+    def self.parse_error_html(body)
+      title = body.respond_to?(:match) && body.match(/<title>(.*)<\/title>/)
+      title ? title[1] : nil
     end
   end
 end

--- a/spec/heroku/command_spec.rb
+++ b/spec/heroku/command_spec.rb
@@ -15,6 +15,11 @@ describe Heroku::Command do
     Heroku::Command.extract_error(response).should == ' !   Invalid app name'
   end
 
+  it "extracts error messages from response when available in HTML" do
+    response = '<html><head><title>Heroku is in maintenance mode.</title></head><body>An error occurred.</html>'
+    Heroku::Command.extract_error(response).should == ' !   Heroku is in maintenance mode.'
+  end
+
   it "shows Internal Server Error when the response doesn't contain a XML or JSON" do
     Heroku::Command.extract_error('<h1>HTTP 500</h1>').should == ' !   Internal server error'
   end
@@ -30,6 +35,10 @@ describe Heroku::Command do
 
   it "handles a nil body in parse_error_json" do
     lambda { Heroku::Command.parse_error_json(nil) }.should_not raise_error
+  end
+
+  it "handles a nil body in parse_error_html" do
+    lambda { Heroku::Command.parse_error_html(nil) }.should_not raise_error
   end
 
   it "correctly resolves commands" do


### PR DESCRIPTION
During "Heroku API is undergoing temporary maintenance", the CLI fails with "! Internal server error" because it's getting an HTML response that the gem doesn't know how to parse, and it took me a while to figure out what was going on. This commit will parse the error from the title of the HTML document.
