### PR TITLE
remove conditional that always evaluates to extract_app

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -32,7 +32,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
   # -r, --raw  # output info as raw key/value pairs
   #
   def info
-    name = (args.first && !args.first =~ /^\-\-/) ? args.first : extract_app
+    name = extract_app
     attrs = heroku.info(name)
 
     attrs[:web_url] ||= "http://#{attrs[:name]}.#{heroku.host}/"


### PR DESCRIPTION
I think this conditional always evaluates to extract_app because the ! binds to args.first and not the match.
