### PR TITLE
fix command help invoked with --help

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -99,10 +99,7 @@ module Heroku
         retry
       end
 
-      if opts[:help]
-        run "help", [cmd]
-        return
-      end
+      raise OptionParser::ParseError if opts[:help]
 
       args.concat(invalid_options)
 

--- a/spec/heroku/command/help_spec.rb
+++ b/spec/heroku/command/help_spec.rb
@@ -27,6 +27,13 @@ describe Heroku::Command::Help do
       output.should_not include "Additional commands"
     end
 
+    it "should show command help with --help" do
+      output = run "apps:create --help"
+      output.should include "heroku apps:create"
+      output.should include "create a new app"
+      output.should_not include "Additional commands"
+    end
+
     describe "with legacy help" do
       require "helper/legacy_help"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,22 @@ def any_instance_of(klass, &block)
   any_instance_of(klass, &block)
 end
 
+def run(command_line)
+  cmd, *args = command_line.split(" ")
+  capture_stdout { Heroku::Command.run(cmd, args) }
+end
+
+def capture_stdout(&block)
+  original_stdout = $stdout
+  $stdout = fake = StringIO.new
+  begin
+    yield
+  ensure
+    $stdout = original_stdout
+  end
+  fake.string
+end
+
 def fail_command(message)
   raise_error(Heroku::Command::CommandFailed, message)
 end


### PR DESCRIPTION
Currently when you invoke a command's help with --help you get:

```
$ heroku db:push --help
Usage: heroku db:push [DATABASE_URL]
 ...
/Users/bozo/.rvm/gems/ruby-1.9.2-p180@tagtree/gems/heroku-2.2.1/lib/heroku/command.rb:117:in `run': nil is  not a symbol (TypeError)
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@tagtree/gems/heroku-2.2.1/bin/heroku:14:in `<top  (required)>'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@tagtree/bin/heroku:19:in `load'
    from /Users/bozo/.rvm/gems/ruby-1.9.2-p180@tagtree/bin/heroku:19:in `<main>'
```

This patch fixes that. This patch depends on OptionParser rescuing. If you don't like that, I could change Command.run (line 114) to:

```
object.send(method) if object
```

Also, I had to bring in more test helper methods as #execute isn't able to test Command.run behavior, which is needed here. It may be worth using the #run test helper in more places if you want to test stdout/stderr more precisely or test the rescues in Command.run.
