### PR TITLE
Client tools for detached process management

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -513,6 +513,10 @@ Console sessions require an open dyno to use for execution.
     post("/apps/#{app}/ps/restart", opts)
   end
 
+  def ps_destroy(app, ps)
+    delete("/apps/#{app}/ps?ps=#{ps}")
+  end
+
   def confirm_billing
     post("/user/#{escape(@user)}/confirm_billing").to_s
   end

--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -122,5 +122,23 @@ class Heroku::Command::Ps < Heroku::Command::Base
 
   alias_command "scale", "ps:scale"
 
+  # ps:stop PROCESS
+  #
+  # stop an app process
+  def restart
+    app = extract_app
+
+    ps = args.first
+    unless ps =~ /.+\..+/
+      error "Usage: heroku ps:stop ps.1"
+    end
+
+    display "Stopping #{ps} process... ", false
+    heroku.ps_destroy(app, ps)
+    display "done"
+  end
+
+  alias_command "restart", "ps:restart"
+
 end
 


### PR DESCRIPTION
I have some detached processes which currently can not be managed through the client. Attached are patches I am using locally for consideration in the official gem.

Example usage:

```
$ bin/heroku ps --app codon-staging-cedar
Process       State               Command
------------  ------------------  ------------------------------

$ bin/heroku ps --all --app codon-staging-cedar
Process       State               Command
------------  ------------------  ------------------------------
receive.1     complete for 2h     echo hello
receive.2     complete for 2h     env
receive.3     complete for 2h     env
receive.4     up for 11s          bin/receive
receive.5     up for 10s          bin/receive
receive.6     up for 10s          bin/receive
receive.7     up for 9s           bin/receive
receive.8     up for 6s           bin/receive

$ bin/heroku ps:stop receive.4 --all --app codon-staging-cedar
Stopping receive.4 process... done

$ bin/heroku ps:stop receive.5 --all --app codon-staging-cedar
Stopping receive.5 process... done

$ bin/heroku ps --all --app codon-staging-cedar
Process       State               Command
------------  ------------------  ------------------------------
receive.1     complete for 2h     echo hello
receive.2     complete for 2h     env
receive.3     complete for 2h     env
receive.6     up for 45s          bin/receive
receive.7     up for 44s          bin/receive
receive.8     up for 41s          bin/receive
```
