### PR TITLE
`config:remove` removes multiple keys at once

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -49,24 +49,25 @@ module Heroku::Command
       display "."
     end
 
-    # config:remove KEY
+    # config:remove KEY1 [KEY2 ...]
     #
     # remove a config var
     #
     def remove
       raise CommandFailed, "Usage: heroku config:remove KEY1 [KEY2 ...]" if args.empty?
-      
-      display "Removing #{args.first} and restarting app...", false
-      heroku.remove_config_var(app, args.first)
 
-      display " done", false
+      args.each do |key|
+        display "Removing #{key} and restarting app...", false
+        heroku.remove_config_var(app, key)
 
-      begin
-        release = heroku.releases(app).last
-        display(", #{release["name"]}", false) if release
-      rescue RestClient::RequestFailed => e
+        display " done", false
+        begin
+          release = heroku.releases(app).last
+          display(", #{release["name"]}", false) if release
+        rescue RestClient::RequestFailed => e
+        end
+        display ".\n"
       end
-      display "."
     end
 
     protected

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -54,12 +54,23 @@ module Heroku::Command
           lambda { @config.remove }.should raise_error(CommandFailed, "Usage: heroku config:remove KEY1 [KEY2 ...]")
         end
       end
-
+      
       context "when one key is provided" do
         let(:args) { ['a'] }
 
         it "removes one key" do
           @config.heroku.should_receive(:remove_config_var).with('myapp', 'a')
+          @config.heroku.should_receive(:releases).and_return([])
+          @config.remove
+        end
+      end
+      
+      context "when more than one key is provided" do
+        let(:args) { ['a', 'b'] }
+
+        it "removes all given keys" do
+          @config.heroku.should_receive(:remove_config_var).with('myapp', 'a')
+          @config.heroku.should_receive(:remove_config_var).with('myapp', 'b')
           @config.heroku.should_receive(:releases).and_return([])
           @config.remove
         end


### PR DESCRIPTION
Hi! Here it is.

But I had to make multiple API requests. I wonder if API support removing multiple keys.

Cheers,
Daniel.
