### PR TITLE
Addon Provision error message and unix-style options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ group :development do
   gem "simplecov", "~> 0.4.2"
   gem "taps",  ">= 0.3.23"
   gem "webmock"
+  gem 'ruby-debug19', :platform => :mri_19
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,15 +10,19 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.2)
+    archive-tar-minitar (0.5.2)
     aws-s3 (0.6.2)
       builder
       mime-types
       xml-simple
     builder (3.0.0)
+    columnize (0.3.4)
     crack (0.1.8)
     diff-lcs (1.1.2)
     fakefs (0.3.1)
     launchy (2.0.3)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     mime-types (1.16)
     parka (0.6.2)
       crack
@@ -37,6 +41,16 @@ GEM
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
     sequel (3.20.0)
     simplecov (0.4.2)
       simplecov-html (~> 0.4.4)
@@ -70,6 +84,7 @@ DEPENDENCIES
   rake (>= 0.8.7)
   rr (~> 1.0.2)
   rspec (>= 2.0)
+  ruby-debug19
   simplecov (~> 0.4.2)
   taps (>= 0.3.23)
   webmock

--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -231,10 +231,8 @@ Console sessions require an open dyno to use for execution.
       prefix + output
     end
   rescue RestClient::RequestFailed => e
-    if Heroku::Command.parse_error_xml(e.http_body)
+    if e.http_code == 422
       Heroku::Command.extract_error(e.http_body)
-    elsif e.http_code == 422
-      e.http_body
     else
       raise e
     end

--- a/lib/heroku/pgutils.rb
+++ b/lib/heroku/pgutils.rb
@@ -27,22 +27,14 @@ module PgUtils
     display(format("%-12s %s", label, info))
   end
 
-  def munge_fork_and_follow(addon)
+  def translate_fork_and_follow(addon, config)
     %w[fork follow].each do |opt|
-      if index = args.index("--#{opt}")
-        val = args.delete_at index+1
-        args.delete_at index
-
+      if val = config[opt]
         resolved = Resolver.new(val, config_vars)
         display resolved.message if resolved.message
         abort_with_database_list(val) unless resolved[:url]
-
-        url = resolved[:url]
-
-        args << "#{opt}=#{url}"
+        config[opt] = resolved[:url]
       end
     end
-    return args
   end
-
 end

--- a/spec/heroku/client_spec.rb
+++ b/spec/heroku/client_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "heroku/client"
 require "heroku/helpers"
+require 'heroku/command'
 
 describe Heroku::Client do
   include Heroku::Helpers
@@ -106,6 +107,11 @@ describe Heroku::Client do
 
   it "console displays xml-formatted errors properly" do
     stub_api_request(:post, "/apps/myapp/console").with(:body => 'command=test').to_return(:status => 422, :body => '<?xml version="1.0"?><errors><error>Test Error</error></errors>')
+    @client.console('myapp', 'test').should == ' !   Test Error'
+  end
+
+  it "console displays json-formatted errors properly" do
+    stub_api_request(:post, "/apps/myapp/console").with(:body => 'command=test').to_return(:status => 422, :body => %|{"error": "Test Error"}|)
     @client.console('myapp', 'test').should == ' !   Test Error'
   end
 


### PR DESCRIPTION
These changes enable unix-style command line options for addon provisioning and add json support to generic 422 responses.
