### PR TITLE
Increase timeouts to connect to one-off processes

### DIFF
--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -21,7 +21,7 @@ class Heroku::Command::Run < Heroku::Command::Base
       $stdin.sync = $stdout.sync = true
       rendezvous = Heroku::Client::Rendezvous.new(
         :rendezvous_url => ps["rendezvous_url"],
-        :connect_timeout => 30,
+        :connect_timeout => (ENV['HEROKU_CONNECT_TIMEOUT'] || 120).to_i,
         :activity_timeout => nil,
         :input => $stdin,
         :output => $stdout)
@@ -123,5 +123,3 @@ protected
     File.open(console_history_file(app), "a") { |f| f.puts cmd + "\n" }
   end
 end
-
-


### PR DESCRIPTION
Not sure if this will help with the issue, but I think it's worth a shot. I made it configurable in case users want to tweak it further, although I cant imagine a higher value would be necessary.

Alternatively, we can leave the default at 30 and just allow it to be configurable, which would enable us in support to tell customers to try a higher value if they're having trouble.

Cheers!
