### PR TITLE
Bug fix for Windows

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -3,7 +3,7 @@ require "vendor/heroku/okjson"
 module Heroku
   module Helpers
     def home_directory
-      running_on_windows? ? ENV['USERPROFILE'] : ENV['HOME']
+      running_on_windows? ? ENV['USERPROFILE'].gsub("\\","/") : ENV['HOME']
     end
 
     def running_on_windows?


### PR DESCRIPTION
After installing heroku-accounts on Windows XP, none of the commands worked properly. "heroku accounts:add --auto" crashed when generating SSH keys. I could add an account without the "--auto" option, but then it was not listed  under "heroku accounts".

I had a look at the source code, opened up irb, and did some experimentation. On my computer ENV['USERPROFILE'] returns: "C:\Documents and Settings\Alex"

Dir["C:\Documents and Settings\Alex"] => []
Dir["C:/Documents and Settings/Alex"] => [ ... ] # it works this way

I thought that all the methods of File and Dir worked the same on paths with either forward slash or backslash separators, but it seems that isn't the case.

This patch fixed the problem for me (in combination with another patch which I am submitting to heroku-accounts).
