### PR TITLE
introduce ps:stop

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -512,6 +512,10 @@ Check the output of "heroku ps" and "heroku logs" for more information.
     post("/apps/#{app}/ps/restart", opts)
   end
 
+  def ps_stop(app, opts={})
+    post("/apps/#{app}/ps/stop", opts)
+  end
+
   def confirm_billing
     post("/user/#{escape(@user)}/confirm_billing").to_s
   end

--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -121,5 +121,30 @@ class Heroku::Command::Ps < Heroku::Command::Base
 
   alias_command "scale", "ps:scale"
 
-end
+  # ps:stop PROCESS
+  #
+  # stop an app process
+  #
+  # Example: heroku stop run.3
+  #
+  def stop
+    app = extract_app
+    opt =
+      if (args.first =~ /.+\..+/)
+        ps = args.first
+        display "Stopping #{ps} process... ", false
+        {:ps => ps}
+      elsif args.first
+        type = args.first
+        display "Stopping #{type} processes... ", false
+        {:type => type}
+      else
+        error "Usage: heroku ps:stop PROCESS"
+      end
 
+    heroku.ps_stop(app, opt)
+    display "done"
+  end
+
+  alias_command "stop", "ps:stop"
+end


### PR DESCRIPTION
Introduces ps:stop, allowing users to manually stop applications process with e.g. `heroku stop run.3`. The primary use case is stopping attached processes.

ps:stop replaces ps:kill, which we don't have particular plans to include in the heroku client.

ps:stop needs some error handling improvements, though I think it makes to implement ps:stop like the other ps:\* commands for now and improve the error handling for all of them together.
