### PR TITLE
pgbackups:wait

### DIFF
--- a/lib/heroku/command/pgbackups.rb
+++ b/lib/heroku/command/pgbackups.rb
@@ -147,6 +147,19 @@ module Heroku::Command
       end
     end
 
+    # pgbackups:wait
+    #
+    # waits till all the transfers are over.
+    #
+    # Its pretty handy in scripts which needs to wait before all the restore/backup transfers are finished
+    def wait
+      ticking do |ticks|
+        transfers = pgbackup_client.get_transfers
+        finished_statuses = transfers.map{|m| m["finished_at"]}
+        return ticks if finished_statuses.compact.length ==  transfers.length #exit if all transfers are finished
+      end
+    end
+
     # pgbackups:destroy BACKUP_ID
     #
     # destroys a backup

--- a/spec/heroku/command/pgbackups_spec.rb
+++ b/spec/heroku/command/pgbackups_spec.rb
@@ -237,5 +237,25 @@ module Heroku::Command
         end
       end
     end
+
+    context "wait" do
+      before do
+        @unfinished_backup_obj = {
+            "finished_at" => nil,
+        }
+        @finished_backup_obj = {
+            "finished_at" => Time.now.to_s,
+        }
+        @pgbackups_client = mock("pgbackups_client")
+        @pgbackups.stub!(:pgbackup_client).and_return(@pgbackups_client)
+      end
+      it "waits for all transfers to finish" do
+        @pgbackups_client.stub(:get_transfers).and_return([@unfinished_backup_obj],[@unfinished_backup_obj,@finished_backup_obj],[@finished_backup_obj,@finished_backup_obj])
+        @pgbackups.should_receive(:sleep).twice
+        @pgbackups.wait
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
Added 'heroku pgbackups:wait'. Its very useful where automated scripts need to ensure that all transfers are finished before proceeding.

People quite often write rake tasks(or automated scripts) to provision/restore db. 
Its often seen that if there is a network error,  heroku command pgbackups:restore die with exception ( very similar to this http://bit.ly/r5ZSAw or http://bit.ly/q84Eob) , this leaves transfers to keep running on heroku side, but client script never gets the info whether is finished finished.

Adding a new method to wait for transfers can fix this problem.

Usage:
  #Restore db
  begin
    system("heroku pgbackups:restore ")
  rescue
    LOGGER.debug("Waiting for pgbackups related transfers to be over.")
    system("heroku pgbackups:wait ")
  end
