### PR TITLE
connect to postgresql domain socket

### DIFF
--- a/lib/heroku/command/db.rb
+++ b/lib/heroku/command/db.rb
@@ -112,11 +112,13 @@ module Heroku::Command
     end
 
     def uri_hash_to_url(uri)
+      host = uri['host']
+      host ||= '127.0.0.1' unless uri['scheme'] == 'postgres'
       uri_parts = {
         :scheme   => uri['scheme'],
         :userinfo => userinfo_from_uri(uri),
         :password => uri['password'],
-        :host     => uri['host'] || '127.0.0.1',
+        :host     => host,
         :port     => uri['port'],
         :path     => "/%s" % uri['path'],
         :query    => uri['query'],

--- a/spec/heroku/command/db_spec.rb
+++ b/spec/heroku/command/db_spec.rb
@@ -24,8 +24,16 @@ module Heroku::Command
       @db.push
     end
 
-    it "defaults host to 127.0.0.1 with a username" do
-      @db.send(:uri_hash_to_url, {'scheme' => 'db', 'username' => 'user', 'path' => 'database'}).should == 'db://user@127.0.0.1/database'
+    describe "without PostgreSQL" do
+      it "defaults host to 127.0.0.1 with a username" do
+        @db.send(:uri_hash_to_url, {'scheme' => 'db', 'username' => 'user', 'path' => 'database'}).should == 'db://user@127.0.0.1/database'
+      end
+    end
+
+    describe "with PostgreSQL" do
+      it "handles lack of host as UNIX domain socket connection" do
+        @db.send(:uri_hash_to_url, {'scheme' => 'postgres', 'path' => 'database'}).should == 'postgres:/database'
+      end
     end
 
     it "handles the lack of a username properly" do


### PR DESCRIPTION
Connecting to a PostgreSQL UNIX domain socket is now supported (host is left empty).

This way heroku db:pull can work without a hostname, username or password (ident based auth).
