### PR TITLE
Let `heroku run` work when $stdin is not a tty.

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -202,6 +202,8 @@ module Heroku
     end
 
     def set_buffer(enable)
+      return unless $stdin.tty?
+
       if enable
         `stty icanon echo`
       else


### PR DESCRIPTION
This lets `heroku run` work from, say, Jenkins.
