### PR TITLE
remove unused String monkey patch from helpers

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -301,11 +301,3 @@ module Heroku
     end
   end
 end
-
-unless String.method_defined?(:shellescape)
-  class String
-    def shellescape
-      empty? ? "''" : gsub(/([^A-Za-z0-9_\-.,:\/@\n])/n, '\\\\\\1').gsub(/\n/, "'\n'")
-    end
-  end
-end


### PR DESCRIPTION
Doesn't appear to be in use (unable to grep it any where and tests pass without it).
