### PR TITLE
Improve error messaging for `heroku addon:open`

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -109,7 +109,11 @@ module Heroku::Command
 
       case matches.length
       when 0 then
-        error "Unknown addon: #{addon}"
+        if heroku.addons.any? {|a| a['name'] =~ /^#{addon}/ }
+          error "No addon matching #{addon} is installed for #{app}"
+        else
+          error "Unknown addon: #{addon}"
+        end
       when 1 then
         addon_to_open = matches.first
         display "Opening #{addon_to_open} for #{app}..."

--- a/spec/heroku/command/addons_spec.rb
+++ b/spec/heroku/command/addons_spec.rb
@@ -266,11 +266,19 @@ module Heroku::Command
         @addons.open
       end
 
-      it "complains if nothing matches" do
-        @addons.heroku.should_receive(:installed_addons).with("myapp").and_return([
-          { "name" => "newrelic:bronze" }
-        ])
+      it "complains if no such addon exists" do
+        @addons.heroku.should_receive(:addons).and_return([])
+        @addons.heroku.should_receive(:installed_addons).with("myapp").and_return([])
         @addons.should_receive(:error).with("Unknown addon: red")
+        @addons.open
+      end
+
+      it "complains if addon is not installed" do
+        @addons.heroku.should_receive(:addons).and_return([
+          { 'name' => 'redistogo:basic' }
+        ])
+        @addons.heroku.should_receive(:installed_addons).with("myapp").and_return([])
+        @addons.should_receive(:error).with("No addon matching red is installed for myapp")
         @addons.open
       end
     end


### PR DESCRIPTION
In particular this improves the messaging for cases where the specified
addon exists but is not installed for the current app.
