### PR TITLE
Extended open method to accept url parameter

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -172,9 +172,13 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   # open the app in a web browser
   #
-  def open
+  def open(url_to_be_opened=nil)
     info = heroku.info(app)
-    url = info[:web_url]
+    unless url_to_be_opened.nil?
+      url = url_to_be_opened
+    else
+      url = info[:web_url]
+    end
     hputs("Opening #{url}")
     Launchy.open url
   end

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -132,6 +132,19 @@ module Heroku::Command
       @cli.destroy
     end
 
+    it "opens default web url if no url is provided" do
+      @cli.heroku.should_receive(:info).with('myapp').and_return(@data)
+      Launchy.should_receive(:open).with(@data[:web_url])
+      @cli.open
+    end
+
+    it "opens provided url if it's passed as an argument" do
+      url_to_be_opened = "http://www.geekbeing.com"
+      @cli.heroku.should_receive(:info).with('myapp').and_return(@data)
+      Launchy.should_receive(:open).with(url_to_be_opened)
+      @cli.open url_to_be_opened
+    end
+
     context "Git Integration" do
       include SandboxHelper
       before(:all) do


### PR DESCRIPTION
Hi

I've tweeted some time ago wishing I could use 'heroku open' to actually open custom domain url rather than default app url. Adam Wiggins (@hirodusk) asked (joking, I've found it funny;)) about the pull request. And I though it was something I had wanted to do for a pretty long time, just wasn't able to find motivation. I'm fairly new to both ruby and github but I did my best to implement this functionality. Just a few short notes:
- I've decided to add an optional parameter to the command in order to keep old behavior - I suppose this also could be done by using domain names kept in heroku app configuration data, but I've found it too complex to decide e.g. which url to pick should there be more than one. If you see a better way of doing it - let me know, I'll implement it
- I haven't noticed any rspec scenarios for the 'open' command so first I've added one, testing the current behavior, then added another one to explain what I'm trying to achieve, then implemented the metod, making sure both specs pass.

I'm really looking forward for your comments
and please understand - this is my first time contributing, tried to do my best, I just know there's a lot to learn -so don't be too harsh ;)

Cheers!
