### PR TITLE
Do not fetch app from current folder on heroku destroy

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -186,6 +186,9 @@ class Heroku::Command::Apps < Heroku::Command::Base
   # permanently destroy an app
   #
   def destroy
+    @app = options[:app] || args.first
+    raise Heroku::Command::CommandFailed, "No app specified.\nSpecify which app to use with --app <app name>" unless @app
+
     heroku.info(app) # fail fast if no access or doesn't exist
 
     if confirm_command

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -126,10 +126,9 @@ module Heroku::Command
     end
 
     it "doesn't destroy the app in the current dir" do
-      @cli.stub!(:app).and_return('myapp')
-      @cli.heroku.stub!(:info).and_return({})
-      @cli.heroku.should_not_receive(:destroy)
-      @cli.destroy
+      @cli.stub!(:options).and_return({})
+      @cli.stub!(:extract_app_in_dir).and_return("myapp")
+      lambda { @cli.destroy }.should raise_error(Heroku::Command::CommandFailed)
     end
 
     context "Git Integration" do


### PR DESCRIPTION
Require the app to be passed as a param/arg instead.

The motivation is to avoid something like:

```
$ heroku destroy app1
! WARNING: Potentially Destructive Action 
! This command will affect the app: very-important-production-app
```
