### PR TITLE
Fix bug in partitioned states that prevented add-ons being listed.

### DIFF
--- a/spec/heroku/command/addons_spec.rb
+++ b/spec/heroku/command/addons_spec.rb
@@ -36,13 +36,17 @@ module Heroku::Command
           { "name" => "cloudcounter:pro", "state" => "public" },
           { "name" => "cloudcounter:gold", "state" => "public" },
           { "name" => "cloudcounter:old", "state" => "disabled" },
-          { "name" => "cloudcounter:platinuam", "state" => "beta" }
+          { "name" => "cloudcounter:platinum", "state" => "beta" }
         ]
         @addons.heroku.stub!(:addons).and_return(@available_addons)
       end
 
       it "lists available addons" do
         @addons.heroku.should_receive(:addons).and_return(@available_addons)
+        @addons.should_receive(:hputs).with("cloudcounter:basic".ljust(34))
+        @addons.should_receive(:hputs).with("cloudcounter:gold, pro".ljust(34))
+        @addons.should_receive(:hputs).with("cloudcounter:platinum".ljust(34))
+        @addons.should_receive(:hputs).with("cloudcounter:old".ljust(34))
         @addons.list
       end
 


### PR DESCRIPTION
I introduced a bug that prevented `heroku addons:list` from working as expected. This fixes that, puts a spec over the desired output, and keeps the previous partitioning state change so we still get the grouped headers.
