### PR TITLE
Default value for Heroku::Updater.home_directory

### DIFF
--- a/lib/heroku/updater.rb
+++ b/lib/heroku/updater.rb
@@ -1,7 +1,7 @@
 module Heroku
   module Updater
     def self.home_directory
-      ENV['HOME'] || ENV['USERPROFILE']
+      ENV['HOME'] || ENV['USERPROFILE'] || ''
     end
 
     def self.running_on_windows?

--- a/spec/updater_spec.rb
+++ b/spec/updater_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'heroku/updater'
+
+describe Heroku::Updater do
+  context 'a user has no home directory' do
+    before do
+      @env = Object.send(:remove_const, :ENV)
+      ENV = {}
+    end
+
+    after do
+      Object.send(:remove_const, :ENV)
+      ENV = @env
+    end
+
+    describe '.updated_client_path' do
+      it 'does not blow up if the user is executing with out a HOME directory' do
+        expect{
+          Heroku::Updater.updated_client_path
+        }.should_not raise_error
+      end
+    end
+
+    describe '.home_directory' do
+      it 'should default to an empty string' do
+        Heroku::Updater.home_directory.should == ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
A story:

I was trying to make Diaspora Heroku compatible.  As it is open source software, we expect Diaspora to run in a variety of environments, including Heroku, with minimal fuss. As such, I included the heroku gem in our Gemfile.  

Currently, we run our production server on a VPS, and use DaemonTools to keep tabs on our processes.  DaemonTools runs processes as a user which does not have  a ENV['HOME'] or ENV['USERPROFILE'] variable set, so when I ran my app server via DaemonTools, it would choke when it required the Heroku gem.

I realize this is a bug which is not directly related to Heroku, but I spent a good amount of time trying to figure out what exactly was happening, as running the server in the foreground worked fine.  As it doesn't change too much code, and it might help some open source nerds out in the future, I hope it is cool to pull in.

I'm willing to try a different approach to solve the problem if this doesn't suit your tastes.

xoxoxo maxwell
