### PR TITLE
Link build status and add dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ For more about Heroku see <http://heroku.com>.
 
 To get started see <http://devcenter.heroku.com/articles/quickstart>
 
-<img src="https://secure.travis-ci.org/heroku/heroku.png" />
+[![Build Status](https://secure.travis-ci.org/heroku/heroku.png)](http://travis-ci.org/heroku/heroku)
+[![Dependency Status](https://gemnasium.com/heroku/heroku.png)](https://gemnasium.com/heroku/heroku)
 
 Setup
 -----


### PR DESCRIPTION
Gemnasium's dependency status is an indicator of whether your gem dependency requirements are up-to-date with the latest versions or if there is room for upgrade.
