### PR TITLE
API key via env vars

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -15,7 +15,7 @@ class Heroku::Auth
     end
 
     def login
-      delete_credentials
+      delete_credentials unless ENV['HEROKU_API_KEY']
       get_credentials
     end
 
@@ -78,8 +78,8 @@ class Heroku::Auth
     end
 
     def read_credentials
-      if ENV['HEROKU_USERNAME'] || ENV['HEROKU_PASSWORD']
-        [ENV['HEROKU_USERNAME'], ENV['HEROKU_PASSWORD']]
+      if ENV['HEROKU_API_KEY']
+        ['', ENV['HEROKU_API_KEY']]
       else
         File.exists?(credentials_file) and File.read(credentials_file).split("\n")
       end

--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -129,8 +129,10 @@ module Heroku
       object.send(method)
     rescue RestClient::Unauthorized
       puts "Authentication failure"
-      run "login"
-      retry
+      unless ENV['HEROKU_API_KEY'] 
+        run "login"
+        retry
+      end
     rescue RestClient::PaymentRequired => e
       retry if run('account:confirm_billing', arguments.dup)
     rescue RestClient::ResourceNotFound => e


### PR DESCRIPTION
Allow user to specify HEROKU_USERNAME and HEROKU_PASSWORD environment variables to override use of credentials file.

> As a user of the heroku gem I want to specify my API key via environment variable so that I can perform automated deployments from an environment on which I cannot easily set ~/.heroku/credentials.
> It is not always appropriate to rely on the ~/.heroku directory to specify the current set of heroku credentials a command should use. For example a continuous integration environment might be deploying multiple heroku apps, each with different credentials, concurrently. Worse the build agents for a CI system may be on remote instances or VMs and it should not be necessary to install a credential set on all build agents in order to safely perform an automated deploy.

I spec'ed out behavior for handling `reauthenticate` when credentials have been set via environment variables and for handling only one of the username/password pair being set. I'd appreciate feedback on if you all think these cases are being handled correctly and consistently with the rest of the gem. 
