### PR TITLE
Gracefully handle an app with no existing releases

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -173,7 +173,8 @@ module Heroku::Command
           end
 
           begin
-            release = heroku.releases(app).last['name']
+            release = heroku.releases(app).last
+            release = release['name'] if release
           rescue RestClient::RequestFailed => e
             release = nil
           end


### PR DESCRIPTION
This change is largely here to support the new `ssl:endpoint` addon, which unlike many other addons, does not create a new release because conceptually a new SSL endpoint is not a change to the state of a Heroku app.
