### PR TITLE
fix pg:wait

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -125,9 +125,9 @@ module Heroku::Command
       specified_db_or_all do |db|
         case db[:name]
         when 'SHARED_DATABASE'
-          return
+          next
         when /\A#{Resolver.shared_addon_prefix}\w+/
-          return
+          next
         else
           wait_for db
         end


### PR DESCRIPTION
pg:wait with no arguments loops over all your database finding one it should
wait for. The returns caused it to exit out of the loop early if a shared
database happened to be found first
