### PR TITLE
add "http://" to proxy if proxy not include protocol

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -542,7 +542,9 @@ Check the output of "heroku ps" and "heroku logs" for more information.
   ##################
 
   def resource(uri, options={})
-    RestClient.proxy = ENV['HTTP_PROXY'] || ENV['http_proxy']
+    proxy = ENV['HTTP_PROXY'] || ENV['http_proxy']
+    proxy = "http://" + proxy unless /^[^:]+:\/\// =~ proxy
+    RestClient.proxy = proxy
     resource = RestClient::Resource.new(realize_full_uri(uri), options.merge(:user => user, :password => password))
     resource
   end


### PR DESCRIPTION
If you access with proxy, you can't use some API ex. 'heroku logs' 'heroku ps' in case of 'http_proxy=host:port'(without protocol)

I modified to add "http://" to proxy if proxy_env not include protocol.
