### PR TITLE
Truncate old API keys to 40 characters

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -112,6 +112,14 @@ class Heroku::Auth
 
         # read netrc credentials if they exist
         if netrc
+          # force migration of long api tokens (80 chars) to short ones (40)
+          # #write_credentials rewrites both api.* and code.*
+          credentials = netrc["api.#{host}"]
+          if credentials && credentials[1].length > 40
+            @credentials = [ credentials[0], credentials[1][0,40] ]
+            write_credentials
+          end
+
           netrc["api.#{host}"]
         end
       end

--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -165,6 +165,16 @@ module Heroku
       Heroku::Netrc.read(@cli.netrc_path)["api.#{@cli.host}"].should == (['one', 'two'])
     end
 
+    it "migrates long api keys to short api keys" do
+      api_key = "7e262de8cac430d8a250793ce8d5b334ae56b4ff15767385121145198a2b4d2e195905ef8bf7cfc5"
+      @cli.netrc["api.#{@cli.host}"] = ["user", api_key]
+
+      @cli.get_credentials.should == ["user", api_key[0,40]]
+      %w{api code}.each do |section|
+        Heroku::Netrc.read(@cli.netrc_path)["#{section}.#{@cli.host}"].should == ["user", api_key[0,40]]
+      end
+    end
+
     describe "automatic key uploading" do
       before(:each) do
         FileUtils.mkdir_p("#{@cli.home_directory}/.ssh")


### PR DESCRIPTION
Hey guys, wanted to get your opinion on this change to get old style 80 character API keys truncated down to the modern 40 character format. I noticed that you were already use `read_credentials` to run the legacy credentials to netrc migration, so I added the truncation code there as well. Let me know if you think that was the right decision.

We'll soon be pushing a fix through to Core that will cause it to disregard anything but the first 40 characters of API keys used during authentication. Obviously this patch will need to wait until after that goes live.

Thanks!
