### PR TITLE
Help option

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -125,7 +125,11 @@ module Heroku
         retry
       end
 
-      raise OptionParser::ParseError if opts[:help]
+      if opts[:help]
+        args.unshift cmd unless cmd =~ /^-.*/
+        cmd = "help"
+        command = parse(cmd)
+      end
 
       args.concat(invalid_options)
 

--- a/spec/heroku/command_spec.rb
+++ b/spec/heroku/command_spec.rb
@@ -146,6 +146,17 @@ describe Heroku::Command do
     Heroku::Command.parse("apps:create").should include(:klass => Heroku::Command::Apps, :method => :create)
   end
 
+  context "help" do
+    it "works as a prefix" do
+      heroku("help ps:scale").should =~ /scale processes by/
+    end
+
+    it "works as an option" do
+      heroku("ps:scale -h").should =~ /scale processes by/
+      heroku("ps:scale --help").should =~ /scale processes by/
+    end
+  end
+
   context "when no commands match" do
 
     it "displays the version if -v or --version is used" do


### PR DESCRIPTION
allow -h and --help options to trigger help

```
$ heroku dynos --help
```
