### PR TITLE
isatty? -> isatty

### DIFF
--- a/lib/heroku/command/logs.rb
+++ b/lib/heroku/command/logs.rb
@@ -38,7 +38,7 @@ module Heroku::Command
       end
     rescue Errno::EPIPE
     rescue Interrupt => interrupt
-      if STDOUT.isatty? && ENV.has_key?("TERM")
+      if STDOUT.isatty && ENV.has_key?("TERM")
         display("\e[0m")
       end
       raise(interrupt)


### PR DESCRIPTION
Hit ^C during `heroku logs -t`, got:

```
/Users/dan/Projects/work/heroku/lib/heroku/command/logs.rb:41:in `rescue in index': undefined method `isatty?' for #<IO:<STDOUT>> (NoMethodError)
    from /Users/dan/Projects/work/heroku/lib/heroku/command/logs.rb:19:in `index'
    from /Users/dan/Projects/work/heroku/lib/heroku/command.rb:140:in `run'
    from /Users/dan/Projects/work/heroku/lib/heroku/cli.rb:9:in `start'
    from /Users/dan/Projects/work/heroku/bin/heroku:16:in `<top (required)>'
    from /Users/dan/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/bin/heroku:19:in `load'
    from /Users/dan/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/bin/heroku:19:in `<main>'
```
