### PR TITLE
fixed failed login over proxy.

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -566,7 +566,7 @@ Check the output of "heroku ps" and "heroku logs" for more information.
   ##################
 
   def resource(uri, options={})
-    RestClient.proxy = case URI.parse(realize_full_uri uri).scheme
+    RestClient.proxy = case URI.parse(realize_full_uri(uri)).scheme
     when "http"
       http_proxy
     when "https"


### PR DESCRIPTION
Client#resource received "/login" as uri, it doesn"t start "http" or "https".
