### PR TITLE
remove hardcoding of bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "rubygems"
-require "bundler/setup"
 
 PROJECT_ROOT = File.expand_path("..", __FILE__)
 $:.unshift "#{PROJECT_ROOT}/lib"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 $stdin = File.new("/dev/null")
 
 require "rubygems"
-Bundler.setup(:default, :test)
 
 require "simplecov"
 SimpleCov.start do


### PR DESCRIPTION
This allows people to run the test suite without depending on bundler.
You can now bundle install to your system gems and just run `rake spec`
and have the tests run.

See #248.
