### PR TITLE
Use current release API in config and addons instead of grabbing all releases

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -178,7 +178,7 @@ module Heroku::Command
           end
 
           begin
-            release = heroku.releases(app).last
+            release = heroku.release(app, 'current')
             release = release['name'] if release
           rescue RestClient::RequestFailed => e
             release = nil

--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -41,7 +41,7 @@ module Heroku::Command
       display " done", false
 
       begin
-        release = heroku.releases(detected_app).last
+        release = heroku.release(detected_app, 'current')
         display(", #{release["name"]}", false) if release
       rescue RestClient::RequestFailed => e
       end
@@ -65,7 +65,7 @@ module Heroku::Command
 
         display " done", false
         begin
-          release = heroku.releases(app).last
+          release = heroku.release(app, 'current')
           display(", #{release["name"]}", false) if release
         rescue RestClient::RequestFailed => e
         end

--- a/spec/heroku/command/addons_spec.rb
+++ b/spec/heroku/command/addons_spec.rb
@@ -9,7 +9,7 @@ module Heroku::Command
     end
 
     before do
-      stub_core.releases("myapp").returns([ "name" => "v99" ])
+      stub_core.release("myapp", "current").returns( "name" => "v99" )
     end
 
     describe "index" do
@@ -65,7 +65,7 @@ module Heroku::Command
         @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
         @addons.add
       end
-      
+
       it "gives a deprecation notice with an example" do
         stub_request(:post, %r{apps/myapp/addons/my_addon$}).
           with(:body => {:config => {:foo => 'bar', :extra => "XXX"}})

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -31,14 +31,14 @@ module Heroku::Command
     it "sets config vars" do
       @config.stub!(:args).and_return(['a=1', 'b=2'])
       @config.heroku.should_receive(:add_config_vars).with('myapp', {'a'=>'1','b'=>'2'})
-      @config.heroku.should_receive(:releases).and_return([])
+      @config.heroku.should_receive(:release)
       @config.add
     end
 
     it "allows config vars with = in the value" do
       @config.stub!(:args).and_return(['a=b=c'])
       @config.heroku.should_receive(:add_config_vars).with('myapp', {'a'=>'b=c'})
-      @config.heroku.should_receive(:releases).and_return([])
+      @config.heroku.should_receive(:release)
       @config.add
     end
 
@@ -50,7 +50,7 @@ module Heroku::Command
 
         it "exits with a help notice" do
           @config.heroku.should_not_receive(:remove_config_var)
-          @config.heroku.should_not_receive(:releases)
+          @config.heroku.should_not_receive(:release)
           lambda { @config.remove }.should raise_error(CommandFailed, "Usage: heroku config:remove KEY1 [KEY2 ...]")
         end
       end
@@ -60,7 +60,7 @@ module Heroku::Command
 
         it "removes one key" do
           @config.heroku.should_receive(:remove_config_var).with('myapp', 'a')
-          @config.heroku.should_receive(:releases).and_return([])
+          @config.heroku.should_receive(:release)
           @config.remove
         end
       end
@@ -71,7 +71,7 @@ module Heroku::Command
         it "removes all given keys" do
           @config.heroku.should_receive(:remove_config_var).with('myapp', 'a')
           @config.heroku.should_receive(:remove_config_var).with('myapp', 'b')
-          @config.heroku.should_receive(:releases).at_least(:once).and_return([])
+          @config.heroku.should_receive(:release).at_least(:once)
           @config.remove
         end
       end


### PR DESCRIPTION
On my app it takes config:add form 28 seconds down to 11.
