### PR TITLE
exit if we signal an error

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -216,6 +216,7 @@ private
     def wait_for(db)
       ticking do |ticks|
         wait_status = heroku_postgresql_client(db[:url]).get_wait_status
+        raise CommandFailed.new(wait_status[:message]) if wait_status[:error?]
         break if !wait_status[:waiting?] && ticks == 0
         redisplay("Waiting for database %s... %s%s" % [
                     db[:pretty_name],


### PR DESCRIPTION
For heroku/ion#408 and heroku/shogun#163

Our normal database contract is: 'don't fail, escalate and resolve'

But for internal alpha stuff we can fail, but we don't signal that to users unless they introspect pg:wait. This is less than obvious and :-(. We should at least let the users know.
