### PR TITLE
Move RequestTimeout rescue before RequestFailed

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -164,10 +164,10 @@ module Heroku
         arguments << '--confirm' << app
         retry
       end
-    rescue RestClient::RequestFailed => e
-      error extract_error(e.http_body)
     rescue RestClient::RequestTimeout
       error "API request timed out. Please try again, or contact support@heroku.com if this issue persists."
+    rescue RestClient::RequestFailed => e
+      error extract_error(e.http_body)
     rescue CommandFailed => e
       error e.message
     rescue OptionParser::ParseError => ex


### PR DESCRIPTION
Since RequestTimeout is a subclass of RequestFailed, we'd never see the specialized error message printed by rescuing a RequestTimeout.
