### PR TITLE
Use new SSL endpoints API namespace

### DIFF
--- a/lib/heroku/client/ssl_endpoint.rb
+++ b/lib/heroku/client/ssl_endpoint.rb
@@ -1,25 +1,25 @@
 class Heroku::Client
   def ssl_endpoint_add(app, pem, key)
-    json_decode(post("v3/apps/#{app}/ssl_endpoints", :accept => :json, :pem => pem, :key => key).to_s)
+    json_decode(post("apps/#{app}/ssl-endpoints", :accept => :json, :pem => pem, :key => key).to_s)
   end
 
   def ssl_endpoint_info(app, cname)
-    json_decode(get("v3/apps/#{app}/ssl_endpoints/#{escape(cname)}", :accept => :json).to_s)
+    json_decode(get("apps/#{app}/ssl-endpoints/#{escape(cname)}", :accept => :json).to_s)
   end
 
   def ssl_endpoint_list(app)
-    json_decode(get("v3/apps/#{app}/ssl_endpoints", :accept => :json).to_s)
+    json_decode(get("apps/#{app}/ssl-endpoints", :accept => :json).to_s)
   end
 
   def ssl_endpoint_remove(app, cname)
-    json_decode(delete("v3/apps/#{app}/ssl_endpoints/#{escape(cname)}", :accept => :json).to_s)
+    json_decode(delete("apps/#{app}/ssl-endpoints/#{escape(cname)}", :accept => :json).to_s)
   end
 
   def ssl_endpoint_rollback(app, cname)
-    json_decode(post("v3/apps/#{app}/ssl_endpoints/#{escape(cname)}/rollback", :accept => :json).to_s)
+    json_decode(post("apps/#{app}/ssl-endpoints/#{escape(cname)}/rollback", :accept => :json).to_s)
   end
 
   def ssl_endpoint_update(app, cname, pem, key)
-    json_decode(put("v3/apps/#{app}/ssl_endpoints/#{escape(cname)}", :accept => :json, :pem => pem, :key => key).to_s)
+    json_decode(put("apps/#{app}/ssl-endpoints/#{escape(cname)}", :accept => :json, :pem => pem, :key => key).to_s)
   end
 end

--- a/spec/heroku/client/ssl_endpoint_spec.rb
+++ b/spec/heroku/client/ssl_endpoint_spec.rb
@@ -7,20 +7,20 @@ describe Heroku::Client, "ssl endpoints" do
   end
 
   it "adds an ssl endpoint" do
-    stub_request(:post, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints").
+    stub_request(:post, "https://api.heroku.com/apps/myapp/ssl-endpoints").
       with(:body => { :accept => "json", :pem => "pem content", :key => "key content" }).
       to_return(:body => %{ {"cname": "tokyo-1050" } })
     @client.ssl_endpoint_add("myapp", "pem content", "key content").should == { "cname" => "tokyo-1050" }
   end
 
   it "gets info on an ssl endpoint" do
-    stub_request(:get, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints/tokyo-1050").
+    stub_request(:get, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050").
       to_return(:body => %{ {"cname": "tokyo-1050" } })
     @client.ssl_endpoint_info("myapp", "tokyo-1050").should == { "cname" => "tokyo-1050" }
   end
 
   it "lists ssl endpoints for an app" do
-    stub_request(:get, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints").
+    stub_request(:get, "https://api.heroku.com/apps/myapp/ssl-endpoints").
       to_return(:body => %{ [{"cname": "tokyo-1050" }, {"cname": "tokyo-1051" }] })
     @client.ssl_endpoint_list("myapp").should == [
       { "cname" => "tokyo-1050" },
@@ -29,18 +29,18 @@ describe Heroku::Client, "ssl endpoints" do
   end
 
   it "removes an ssl endpoint" do
-    stub_request(:delete, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints/tokyo-1050")
+    stub_request(:delete, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050")
     @client.ssl_endpoint_remove("myapp", "tokyo-1050")
   end
 
   it "rolls back an ssl endpoint" do
-    stub_request(:post, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints/tokyo-1050/rollback").
+    stub_request(:post, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050/rollback").
       to_return(:body => %{ {"cname": "tokyo-1050" } })
     @client.ssl_endpoint_rollback("myapp", "tokyo-1050").should == { "cname" => "tokyo-1050" }
   end
 
   it "updates an ssl endpoint" do
-    stub_request(:put, "https://api.heroku.com/v3/apps/myapp/ssl_endpoints/tokyo-1050").
+    stub_request(:put, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050").
       with(:body => { :accept => "json", :pem => "pem content", :key => "key content" }).
       to_return(:body => %{ {"cname": "tokyo-1050" } })
     @client.ssl_endpoint_update("myapp", "tokyo-1050", "pem content", "key content").should == { "cname" => "tokyo-1050" }


### PR DESCRIPTION
The SSL endpoints API being in the v3/ URL namespace never really made sense, so this change moves the Gem over to a more consistent SSL endpoints API before certs goes GA.

The old `v3/apps/:app_id/ssl_endpoints` namespace will continue to function normally for the time being for all clients who used certs throughout the beta period.

@geemus -- It would be awesome if we put this sometime before GA. No particular rush.
