### PR TITLE
allow people to use custom heroku subdomains to use ssh config and multiple identities

### DIFF
--- a/lib/heroku/command/base.rb
+++ b/lib/heroku/command/base.rb
@@ -202,7 +202,7 @@ protected
     return unless File.exists?(".git")
     git("remote -v").split("\n").each do |remote|
       name, url, method = remote.split(/\s/)
-      if url =~ /^git@#{heroku.host}:([\w\d-]+)\.git$/
+      if url =~ /^git@(?:[a-zA-Z0-9-]+\.)*#{heroku.host}:([\w\d-]+)\.git$/
         remotes[name] = $1
       end
     end

--- a/spec/heroku/command/base_spec.rb
+++ b/spec/heroku/command/base_spec.rb
@@ -65,6 +65,24 @@ other\tgit@other.com:other.git (push)
         @base.send(:git_remotes, '/home/dev/myapp').should == { 'staging' => 'myapp-staging', 'production' => 'myapp' }
       end
 
+      it "read remotes from git config when using custom subdomains" do
+        Dir.stub(:chdir)
+        File.should_receive(:exists?).with(".git").and_return(true)
+        @base.should_receive(:git).with('remote -v').and_return(<<-REMOTES)
+staging\tgit@myhost.heroku.com:myapp-staging.git (fetch)
+staging\tgit@myhost.heroku.com:myapp-staging.git (push)
+production\tgit@this-is-production.heroku.com:myapp-production.git (fetch)
+production\tgit@this-is-production.heroku.com:myapp-production.git (push)
+        REMOTES
+
+        @heroku = mock
+        @heroku.stub(:host).and_return('heroku.com')
+        @base.stub(:heroku).and_return(@heroku)
+
+        # need a better way to test internal functionality
+        @base.send(:git_remotes, '/home/dev/myapp').should == { 'staging' => 'myapp-staging', 'production' => 'myapp-production' }
+      end
+
       it "gets the app from remotes when there's only one app" do
         @base.stub!(:git_remotes).and_return({ 'heroku' => 'myapp' })
         @base.stub!(:git).with("config heroku.remote").and_return("")


### PR DESCRIPTION
When using multiple identities like in the heroku accounts plugin, the preferred way is setting the heroku remote to point to a custom host like myaccount1.heroku.com, myaccount2.heroku.com, etc.., so that ssh config can be used to send different identities corresponding to different custom hosts. Unfortunately heroku won't recognize the remote anymore as a valid app (because it expects exactly heroku.com). I think it shouldn't hurt to allow custom subdomains to be matched as valid heroku apps but it would quite be useful with multiple account setups. So here my fix.

Federico
