### PR TITLE
Client command requires a symbol rather than a string

### DIFF
--- a/lib/heroku/command/maintenance.rb
+++ b/lib/heroku/command/maintenance.rb
@@ -17,7 +17,7 @@ class Heroku::Command::Maintenance < Heroku::Command::Base
     validate_arguments!
 
     action("Enabling maintenance mode for #{app}") do
-      api.post_app_maintenance(app, 'on')
+      api.post_app_maintenance(app, :on)
     end
 
     #heroku.maintenance(app, :on)
@@ -37,7 +37,7 @@ class Heroku::Command::Maintenance < Heroku::Command::Base
     validate_arguments!
 
     action("Disabling maintenance mode for #{app}") do
-      api.post_app_maintenance(app, 'off')
+      api.post_app_maintenance(app, :off)
     end
 
     #heroku.maintenance(app, :off)


### PR DESCRIPTION
https://github.com/heroku/heroku/blob/master/lib/heroku/client.rb#L513

The logic to turn the maintenance page on or off is determined by equality against a symbol. However, a string was been passed to this method which was always causing `mode` to evaluate to `0` causing every maintenance call to turn the maintenance page off.

This fixes issue #355.
