### PR TITLE
Workaround for #337, force UTF-8 encoding

### DIFF
--- a/lib/heroku/client/rendezvous.rb
+++ b/lib/heroku/client/rendezvous.rb
@@ -60,6 +60,7 @@ class Heroku::Client::Rendezvous
             rescue EOFError
               break
             end
+            data.force_encoding("utf-8")
             output.write(fixup(data))
           end
         else


### PR DESCRIPTION
I suspect this is not the right fix, but if anyone is running into this problem, here's a workaround.
See #337.
