### PR TITLE
Heroku::Client::Rendezvous#fixup: do not break on String#force_encoding

### DIFF
--- a/lib/heroku/client/rendezvous.rb
+++ b/lib/heroku/client/rendezvous.rb
@@ -84,7 +84,7 @@ class Heroku::Client::Rendezvous
   private
 
   def fixup(data)
-    data.force_encoding('utf-8')
+    data.force_encoding('utf-8') if data.class.method_defined?(:force_encoding)
     output.isatty ? data : data.gsub(/\cM/,"")
   end
 end


### PR DESCRIPTION
String#force_encoding only exists and is only necessary in rubies (e.g. MRI 1.9) where string[x] returns a code point rather than a character.
