### PR TITLE
A better fix for #346.

### DIFF
--- a/lib/heroku/client/rendezvous.rb
+++ b/lib/heroku/client/rendezvous.rb
@@ -84,7 +84,7 @@ class Heroku::Client::Rendezvous
   private
 
   def fixup(data)
-    data.force_encoding('utf-8') if data.class.method_defined?(:force_encoding)
+    data.force_encoding('utf-8') if data.respond_to?(:force_encoding)
     output.isatty ? data : data.gsub(/\cM/,"")
   end
 end


### PR DESCRIPTION
The `data.class.method_defined?(:force_encoding)` call will return a false positive if you have, for example, a private `:force_encoding` method. The standard ruby way to fix this seems to see if `data.respond_to?`.

``` ruby
ruby-1.8.7-p352 :002 > "".respond_to?(:force_encoding)
 => false 
```

``` ruby
ruby-1.9.2-p290 :002 > "".respond_to?(:force_encoding)
 => true 
```
