### PR TITLE
override port and scheme

### DIFF
--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -24,6 +24,12 @@ module Heroku
 
     before(:each) do
       @cli.credentials = nil
+
+      home_directory = @cli.netrc_path.split("/")[0..-2].join("/")
+      unless File.exists?(home_directory)
+        FileUtils.mkdir_p(home_directory)
+      end
+
       File.open(@cli.netrc_path, "w") do |file|
         file.puts("machine api.heroku.com\n  login user\n  password pass\n")
         file.puts("machine code.heroku.com\n  login user\n  password pass\n")


### PR DESCRIPTION
This pull request allows for people to specify a `HEROKU_HOST` with port and http or https. It also fixes failing specs on travis around `heroku/auth_spec.rb`.
