### PR TITLE
Promotes DATABASE_URL when we do a heroku pg:credentials --reset

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -44,8 +44,8 @@ class Heroku::Command::Pg < Heroku::Command::Base
   #
   # Sets DATABASE as your DATABASE_URL
   #
-  def promote(db = shift_argument)
-    unless db
+  def promote
+    unless db = shift_argument
       error("Usage: heroku pg:promote DATABASE")
     end
     validate_arguments!
@@ -58,7 +58,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     end
 
     action "Promoting #{display_name} to DATABASE_URL" do
-      api.put_config_vars(app, "DATABASE_URL" => url)
+      hpg_promote(url)
     end
   end
 
@@ -176,7 +176,9 @@ class Heroku::Command::Pg < Heroku::Command::Base
       if url_is_database_url
         forget_config!
         name, new_url = hpg_resolve(db)
-        promote(new_url)
+        action "Promoting #{name}" do
+          hpg_promote(new_url)
+        end
       end
     else
       uri = URI.parse(url)

--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -91,4 +91,8 @@ module Heroku::Helpers::HerokuPostgresql
     end
   end
 
+  def hpg_promote(url)
+    api.put_config_vars(app, "DATABASE_URL" => url)
+  end
+
 end

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -173,7 +173,7 @@ STDERR
         stderr.should be_empty
         stdout.should == <<-STDOUT
 Resetting credentials for HEROKU_POSTGRESQL_RESETME (DATABASE_URL)... done
-Promoting custom URL to DATABASE_URL... done
+Promoting HEROKU_POSTGRESQL_RESETME (DATABASE_URL)... done
 STDOUT
       end
 


### PR DESCRIPTION
When a user does a `heroku pg:credentials --reset` we can update the addon URL, but we can't override/promote to DATABASE_URL.

This commit promotes DATABASE_URL when necessary by invoking the existing `#promote` method. Output looks like this:

```
$ bundle exec bin/heroku pg:info brown                                                                                                                                                                                                       
=== HEROKU_POSTGRESQL_BROWN (DATABASE_URL)
Conn Info:   
  [Deprecated] Please use `heroku pg:credentials HEROKU_POSTGRESQL_BROWN` to view connection info

Connections: 1
Created:     2012-05-29 19:47 UTC
Data Size:   16384
Fork/Follow: Unavailable
PG Version:  9.1.3
Plan:        Dev
Rows:        0
Status:      available
Tables:      1

$ bundle exec bin/heroku pg:credentials --reset brown                                                                                                                                                                                    
Resetting credentials for HEROKU_POSTGRESQL_BROWN (DATABASE_URL)... done
Promoting custom URL to DATABASE_URL... done
$ 
```
