### PR TITLE
Heroku::Auth - Add error checking when creating and uploading SSH key

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -270,23 +270,10 @@ class Heroku::Auth
           File.chmod(0700, ssh_dir)
         end
       end
-      if which('ssh-keygen')
-        `ssh-keygen -t rsa -N "" -f \"#{home_directory}/.ssh/#{keyfile}\" 2>&1`
-      else
-        error("Could not generate key: ssh-keygen doesn't exist. Please install it or make sure it's in your path.")
+      output = `ssh-keygen -t rsa -N "" -f \"#{home_directory}/.ssh/#{keyfile}\" 2>&1`
+      if ! $?.success?
+        error("Could not generate key: #{output}")
       end
-    end
-
-    # check if an executable exists anywhere in the path
-    def which(cmd)
-      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
-      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-        exts.each { |ext|
-          exe = "#{path}/#{cmd}#{ext}"
-          return exe if File.executable? exe
-        }
-      end
-      return nil
     end
 
     def associate_key(key)


### PR DESCRIPTION
Hello! I'm wondering if you're interested in a bit more error checking during the login script. I have also created a help ticket in your help system ( https://support.heroku.com/requests/54687 ).
## 

Repro steps:
- Install the Heroku Toolbelt on a system that does not have 'ssh-keygen' in the path (or simply remove ssh-keygen from the path before running)
- Make sure you do not have any key files (or anything named "*.pub") in ~/.ssh/
- Run 'heroku login'
- When heroku asks if you want to generate a new key, type 'y'

You will see an error like "Uploading SSH public key /some/path/.ssh/id_rsa.pub... /some/other/path/lib/heroku/auth.rb:278:in `read': No such file or directory - /some/path/.ssh/id_rsa.pub (Errno::ENOENT)"
## 

(_edit_: add repro steps and link to help ticket)
