### PR TITLE
Solves nil value for config var.

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -136,7 +136,9 @@ class Heroku::Command::Config < Heroku::Command::Base
   private
   def quote_vars!(vars)
     vars.keys.each do |key|
-      if vars[key].include?(' ')
+      if vars[key].nil?
+        vars[key] = ''
+      elsif vars[key].include?(' ')
         vars[key] = %{"#{vars[key]}"}
       end
     end

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -43,6 +43,17 @@ SPACED: "foo bar"
 STDOUT
     end
 
+    it "handles when value is nil" do
+      api.put_config_vars("myapp", { 'FOO_BAR' => 'one', 'BAZ_QUX' => nil })
+      stderr, stdout = execute("config")
+      stderr.should == ""
+      stdout.should == <<-STDOUT
+=== Config Vars for myapp
+BAZ_QUX: 
+FOO_BAR: one
+STDOUT
+    end
+
     it "shows configs in a shell compatible format" do
       api.put_config_vars("myapp", { 'A' => 'one', 'B' => 'two' })
       stderr, stdout = execute("config --shell")


### PR DESCRIPTION
Fixes #400.

The Heroku API can return nil for a config var, like this:

{"COMMIT_HASH"=>nil}

This will cause the client to blow up. This sets the value to '', so the
client doesn't blow up.
