### PR TITLE
stringify all the config var values, handle booleans.

### DIFF
--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -136,10 +136,11 @@ class Heroku::Command::Config < Heroku::Command::Base
   private
   def quote_vars!(vars)
     vars.keys.each do |key|
-      if vars[key].nil?
-        vars[key] = ''
-      elsif vars[key].include?(' ')
-        vars[key] = %{"#{vars[key]}"}
+      value = vars[key].to_s
+      if value.include?(' ')
+        vars[key] = %{"#{value}"}
+      else
+        vars[key] = value
       end
     end
     vars

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -54,6 +54,17 @@ FOO_BAR: one
 STDOUT
     end
 
+    it "handles when value is a boolean" do
+      api.put_config_vars("myapp", { 'FOO_BAR' => 'one', 'BAZ_QUX' => true })
+      stderr, stdout = execute("config")
+      stderr.should == ""
+      stdout.should == <<-STDOUT
+=== Config Vars for myapp
+BAZ_QUX: true
+FOO_BAR: one
+STDOUT
+    end
+
     it "shows configs in a shell compatible format" do
       api.put_config_vars("myapp", { 'A' => 'one', 'B' => 'two' })
       stderr, stdout = execute("config --shell")


### PR DESCRIPTION
The Heroku API can return a boolean for a config var, like this:

{"COMMIT_HASH"=>true}

This will cause the client to blow up. This sets the value to true or
false depending on the boolean, so client doesn't blow up.

This will handle both the nil/boolean case as well as stringifying all the values.
