### PR TITLE
simplify before/after blocks

### DIFF
--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -32,6 +32,7 @@ module Heroku
     end
 
     after do
+      FileUtils.rm_rf(@cli.netrc_path)
       FakeFS.deactivate!
     end
 


### PR DESCRIPTION
There were multiple `before`/`after` blocks and resulted in `~/.netrc` getting deleted. I consolidated the blocks into one `before` and one `after` block.
