### PR TITLE
output the app name from the API response

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -66,7 +66,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
     app_data = api.get_app(app).body
 
     unless options[:raw]
-      styled_header(app)
+      styled_header(app_data["name"])
     end
 
     addons_data = api.get_addons(app).body.map {|addon| addon["description"]}.sort


### PR DESCRIPTION
display the app name returned in the API response instead of what is passed to `-a`
