### PR TITLE
don't display credentials on pg:info on forks/followers on another app.

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -191,7 +191,12 @@ private
 
   def database_name_from_url(url)
     vars = app_config_vars.reject {|key,value| key == 'DATABASE_URL'}
-    (vars.invert[url] || url).gsub(/_URL$/, "")
+    if var = vars.invert[url]
+      var.gsub(/_URL$/, '')
+    else
+      uri = URI.parse(url)
+      "Database on #{uri.hostname}:#{uri.port}#{uri.path}"
+    end
   end
 
   def display_db(name, db)

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -97,6 +97,7 @@ STDOUT
           {"name"=>"Tables", "values"=>[1]},
           {"name"=>"PG Version", "values"=>["9.1.4"]},
           {"name"=>"Fork/Follow", "values"=>["Available"]},
+          {"name"=>"Forked From", "values"=>["postgres://username:password@postgreshost.com:5432/database_name"], "resolve_db_name" => "true"},
           {"name"=>"Created", "values"=>["2011-12-13 00:00 UTC"]},
           {"name"=>"Conn Info", "values"=>["[Deprecated] Please use `heroku pg:credentials HEROKU_POSTGRESQL_RONIN` to view connection info"]},
           {"name"=>"Maintenance", "values"=>["not required"]}
@@ -112,6 +113,7 @@ Data Size:   1 MB
 Tables:      1
 PG Version:  9.1.4
 Fork/Follow: Available
+Forked From: Database on postgreshost.com:5432/database_name
 Created:     2011-12-13 00:00 UTC
 Conn Info:   [Deprecated] Please use `heroku pg:credentials HEROKU_POSTGRESQL_RONIN` to view connection info
 Maintenance: not required


### PR DESCRIPTION
It is possible to create forks and followers on a different app to where
the parent lives. In this case, the database url cannot be matched up
with a config var.

Prior to this patch, the client would display the full URL, which is
something we are getting away from for security reasons. Instead,
this patch shows hostname/port/database name.
