### PR TITLE
don't display credentials on pg:info on forks/followers on another app.

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -195,7 +195,7 @@ private
       var.gsub(/_URL$/, '')
     else
       uri = URI.parse(url)
-      "Database on #{uri.hostname}:#{uri.port}#{uri.path}"
+      "Database on #{uri.host}:#{uri.port || 5432}#{uri.path}"
     end
   end
 

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -195,7 +195,7 @@ STDOUT
         Heroku::Client::HerokuPostgresql.should_receive(:new).twice.with('postgres://other_database_url').and_return(hpg_client)
         hpg_client.should_receive(:unfollow)
         hpg_client.should_receive(:get_database).and_return(
-          :following => 'postgresql://ronin_database_url',
+          :following => 'postgresql://user:pass@roninhost/database',
           :info => [
             {"name"=>"Plan", "values"=>["Ronin"]},
             {"name"=>"Status", "values"=>["available"]},
@@ -212,7 +212,7 @@ STDOUT
         stderr.should == ""
         stdout.should == <<-STDOUT
  !    HEROKU_POSTGRESQL_OTHER will become writable and no longer
- !    follow postgresql://ronin_database_url. This cannot be undone.
+ !    follow Database on roninhost:5432/database. This cannot be undone.
 Unfollowing HEROKU_POSTGRESQL_OTHER... done
 STDOUT
       end


### PR DESCRIPTION
A followup on https://github.com/heroku/heroku/pull/465. 

@geemus, let me know if that passes and looks good.
