### PR TITLE
Allow alternate netrc files

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -101,7 +101,11 @@ class Heroku::Auth
     end
 
     def netrc_path
-      default = Netrc.default_path
+      if ENV['HEROKU_NETRC']
+        default = ENV['HEROKU_NETRC']
+      else
+        default = Netrc.default_path
+      end
       encrypted = default + ".gpg"
       if File.exists?(encrypted)
         encrypted


### PR DESCRIPTION
If the user has multiple heroku accounts, allow them to change to a
different netrc using an environment variable. Then the variable can be
set in the virtualenv to make everyone happier.
