### PR TITLE
Standardize casing of 'SSL Endpoint' on all certs output

### DIFF
--- a/lib/heroku/command/certs.rb
+++ b/lib/heroku/command/certs.rb
@@ -1,18 +1,18 @@
 require "heroku/command/base"
 
-# manage ssl endpoints for an app
+# manage SSL Endpoints for an app
 #
 class Heroku::Command::Certs < Heroku::Command::Base
 
   # certs
   #
-  # list SSL endpoints for an app
+  # list SSL Endpoints for an app
   #
   def index
     endpoints = heroku.ssl_endpoint_list(app)
 
     if endpoints.empty?
-      display "#{app} has no SSL endpoints."
+      display "#{app} has no SSL Endpoints."
       display "Use `heroku certs:add PEM KEY` to add one."
     else
       endpoints.map! do |endpoint|
@@ -33,14 +33,14 @@ class Heroku::Command::Certs < Heroku::Command::Base
 
   # certs:add PEM KEY
   #
-  # add an SSL endpoint to an app
+  # add an SSL Endpoint to an app
   #
   def add
     fail("Usage: heroku certs:add PEM KEY\nMust specify PEM and KEY to add cert.") if args.size < 2
     pem = File.read(args[0]) rescue error("Unable to read #{args[0]} PEM")
     key = File.read(args[1]) rescue error("Unable to read #{args[1]} KEY")
 
-    endpoint = action("Adding SSL endpoint to #{app}") do
+    endpoint = action("Adding SSL Endpoint to #{app}") do
       heroku.ssl_endpoint_add(app, pem, key)
     end
 
@@ -52,11 +52,11 @@ class Heroku::Command::Certs < Heroku::Command::Base
 
   # certs:info
   #
-  # show certificate information for an SSL endpoint
+  # show certificate information for an SSL Endpoint
   #
   def info
     cname = options[:endpoint] || current_endpoint
-    endpoint = action("Fetching SSL endpoint #{cname} info for #{app}") do
+    endpoint = action("Fetching SSL Endpoint #{cname} info for #{app}") do
       heroku.ssl_endpoint_info(app, cname)
     end
 
@@ -66,20 +66,20 @@ class Heroku::Command::Certs < Heroku::Command::Base
 
   # certs:remove
   #
-  # remove an SSL endpoint from an app
+  # remove an SSL Endpoint from an app
   #
   def remove
     cname = options[:endpoint] || current_endpoint
-    action("Removing SSL endpoint #{cname} from #{app}") do
+    action("Removing SSL Endpoint #{cname} from #{app}") do
       heroku.ssl_endpoint_remove(app, cname)
     end
     display "De-provisioned endpoint #{cname}."
-    display "NOTE: Billing is still active. Remove SSL endpoint add-on to stop billing."
+    display "NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing."
   end
 
   # certs:update PEM KEY
   #
-  # update an SSL endpoint on an app
+  # update an SSL Endpoint on an app
   #
   def update
     fail("Usage: heroku certs:update PEM KEY\nMust specify PEM and KEY to update cert.") if args.size < 2
@@ -88,7 +88,7 @@ class Heroku::Command::Certs < Heroku::Command::Base
     app = self.app
     cname = options[:endpoint] || current_endpoint
 
-    endpoint = action("Updating SSL endpoint #{cname} for #{app}") do
+    endpoint = action("Updating SSL Endpoint #{cname} for #{app}") do
       heroku.ssl_endpoint_update(app, cname, pem, key)
     end
 
@@ -99,12 +99,12 @@ class Heroku::Command::Certs < Heroku::Command::Base
 
   # certs:rollback
   #
-  # rollback an SSL endpoint for an app
+  # rollback an SSL Endpoint for an app
   #
   def rollback
     cname = options[:endpoint] || current_endpoint
 
-    endpoint = action("Rolling back SSL endpoint #{cname} for #{app}") do
+    endpoint = action("Rolling back SSL Endpoint #{cname} for #{app}") do
       heroku.ssl_endpoint_rollback(app, cname)
     end
 
@@ -115,7 +115,7 @@ class Heroku::Command::Certs < Heroku::Command::Base
   private
 
   def current_endpoint
-    endpoint = heroku.ssl_endpoint_list(app).first || error("#{app} has no SSL endpoints.")
+    endpoint = heroku.ssl_endpoint_list(app).first || error("#{app} has no SSL Endpoints.")
     endpoint["cname"]
   end
 

--- a/spec/heroku/command/certs_spec.rb
+++ b/spec/heroku/command/certs_spec.rb
@@ -51,11 +51,11 @@ akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True
 STDOUT
       end
 
-      it "warns about no SSL endpoints if the app has no certs" do
+      it "warns about no SSL Endpoints if the app has no certs" do
         stub_core.ssl_endpoint_list("myapp").returns([])
         stderr, stdout = execute("certs")
         stdout.should == <<-STDOUT
-myapp has no SSL endpoints.
+myapp has no SSL Endpoints.
 Use `heroku certs:add PEM KEY` to add one.
         STDOUT
       end
@@ -69,7 +69,7 @@ Use `heroku certs:add PEM KEY` to add one.
 
         stderr, stdout = execute("certs:add pem_file key_file")
         stdout.should == <<-STDOUT
-Adding SSL endpoint to myapp... done
+Adding SSL Endpoint to myapp... done
 myapp now served by tokyo-1050.herokussl.com
 Certificate details:
 #{certificate_details}
@@ -88,7 +88,7 @@ Certificate details:
 
         stderr, stdout = execute("certs:info")
         stdout.should == <<-STDOUT
-Fetching SSL endpoint tokyo-1050.herokussl.com info for myapp... done
+Fetching SSL Endpoint tokyo-1050.herokussl.com info for myapp... done
 Certificate details:
 #{certificate_details}
         STDOUT
@@ -99,7 +99,7 @@ Certificate details:
 
         stderr, stdout = execute("certs:info")
         stderr.should == <<-STDERR
- !    myapp has no SSL endpoints.
+ !    myapp has no SSL Endpoints.
         STDERR
       end
     end
@@ -110,9 +110,9 @@ Certificate details:
         stub_core.ssl_endpoint_remove('myapp', 'tokyo-1050.herokussl.com').returns(endpoint)
 
         stderr, stdout = execute("certs:remove")
-        stdout.should include "Removing SSL endpoint tokyo-1050.herokussl.com from myapp..."
+        stdout.should include "Removing SSL Endpoint tokyo-1050.herokussl.com from myapp..."
         stdout.should include "De-provisioned endpoint tokyo-1050.herokussl.com."
-        stdout.should include "NOTE: Billing is still active. Remove SSL endpoint add-on to stop billing."
+        stdout.should include "NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing."
       end
 
       it "shows an error if an app has no endpoints" do
@@ -120,7 +120,7 @@ Certificate details:
 
         stderr, stdout = execute("certs:remove")
         stderr.should == <<-STDERR
- !    myapp has no SSL endpoints.
+ !    myapp has no SSL Endpoints.
         STDERR
       end
     end
@@ -137,7 +137,7 @@ Certificate details:
 
         stderr, stdout = execute("certs:update pem_file key_file")
         stdout.should == <<-STDOUT
-Updating SSL endpoint tokyo-1050.herokussl.com for myapp... done
+Updating SSL Endpoint tokyo-1050.herokussl.com for myapp... done
 Updated certificate details:
 #{certificate_details}
         STDOUT
@@ -148,7 +148,7 @@ Updated certificate details:
 
         stderr, stdout = execute("certs:update pem_file key_file")
         stderr.should == <<-STDERR
- !    myapp has no SSL endpoints.
+ !    myapp has no SSL Endpoints.
         STDERR
       end
     end
@@ -160,7 +160,7 @@ Updated certificate details:
 
         stderr, stdout = execute("certs:rollback")
         stdout.should == <<-STDOUT
-Rolling back SSL endpoint tokyo-1050.herokussl.com for myapp... done
+Rolling back SSL Endpoint tokyo-1050.herokussl.com for myapp... done
 New active certificate details:
 #{certificate_details}
         STDOUT
@@ -171,7 +171,7 @@ New active certificate details:
 
         stderr, stdout = execute("certs:rollback")
         stderr.should == <<-STDERR
- !    myapp has no SSL endpoints.
+ !    myapp has no SSL Endpoints.
         STDERR
       end
     end


### PR DESCRIPTION
Wesley's last certs pull reminded me that when Craig owned this product, we made a bit of headway standardizing the casing of the `ssl:endpoint` addon. It shouldn't be 'SSL endpoint' or 'ssl endpoint', but rather 'SSL Endpoint'. Much of the Devcenter documentation has already been updated, but not all of it, and the CLI been off for a while.

/cc @kr @geemus 
