### PR TITLE
Fix docs and options check for apps:info

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -56,7 +56,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
   # Repo Size: 5M
   # ...
   #
-  # $ heroku apps:info --raw
+  # $ heroku apps:info --shell
   # git_url=git@heroku.com:myapp.git
   # repo_size=5000000
   # ...
@@ -65,7 +65,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
     validate_arguments!
     app_data = api.get_app(app).body
 
-    unless options[:raw]
+    unless options[:shell]
       styled_header(app_data["name"])
     end
 


### PR DESCRIPTION
In #529 (see cbbeada) @geemus removed  the --raw parameter but there is still a reference to it in the code and another one in the docs (that are displayed if you use --raw as it's now a invalid argument). Small fix to this bugs.
