### PR TITLE
remove aspen from example stack list

### DIFF
--- a/lib/heroku/command/stack.rb
+++ b/lib/heroku/command/stack.rb
@@ -13,7 +13,6 @@ module Heroku::Command
     #
     # $ heroku stack
     # === myapp Available Stacks
-    #   aspen-mri-1.8.6
     #   bamboo-mri-1.9.2
     #   bamboo-ree-1.8.7
     # * cedar


### PR DESCRIPTION
For modern apps, `heroku stack` no longer shows Aspen.
