### PR TITLE
remove redundant messaging on ssl endpoint cert removal

### DIFF
--- a/lib/heroku/command/certs.rb
+++ b/lib/heroku/command/certs.rb
@@ -73,7 +73,6 @@ class Heroku::Command::Certs < Heroku::Command::Base
     action("Removing SSL Endpoint #{cname} from #{app}") do
       heroku.ssl_endpoint_remove(app, cname)
     end
-    display "De-provisioned endpoint #{cname}."
     display "NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing."
   end
 

--- a/spec/heroku/command/certs_spec.rb
+++ b/spec/heroku/command/certs_spec.rb
@@ -111,7 +111,6 @@ Certificate details:
 
         stderr, stdout = execute("certs:remove")
         stdout.should include "Removing SSL Endpoint tokyo-1050.herokussl.com from myapp..."
-        stdout.should include "De-provisioned endpoint tokyo-1050.herokussl.com."
         stdout.should include "NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing."
       end
 


### PR DESCRIPTION
Endpoint removal goes from:

``` bash
$ heroku certs:remove -a test-ssl-endpoint
Removing SSL Endpoint iwate-4219.herokussl.com from test-ssl-endpoint... done
De-provisioned endpoint iwate-4219.herokussl.com.
NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing.
```

To:

``` bash
$ heroku certs:remove -a test-ssl-endpoint
Removing SSL Endpoint iwate-4219.herokussl.com from test-ssl-endpoint... done
NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing.
```
