### PR TITLE
Fix DB promotion after credential roll

### DIFF
--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -82,6 +82,7 @@ module Heroku::Helpers::HerokuPostgresql
   def forget_config!
     @hpg_databases   = nil
     @app_config_vars = nil
+    @app_attachments = nil
   end
 
   def find_database_url_real_attachment


### PR DESCRIPTION
The issue was that the cached database URLs were not being cleared. This regression was introduced whenever we switched to calling it `attachments`.

Fixes heroku/heroku#628

Before this fix, note different database urls after the credential roll:

```
[master][~/src/heroku] be bin/heroku pg:credentials --reset black -ahgmnz                            
Resetting credentials for HEROKU_POSTGRESQL_BLACK_URL (DATABASE_URL)... done
Promoting HEROKU_POSTGRESQL_BLACK_URL (DATABASE_URL)... done
[master][~/src/heroku] be bin/heroku config -ahgmnz                      
=== hgmnz Config Vars
DATABASE_URL:                postgres://iexppeybmrdpvc:f8peIsdBwYgqQzhUFWpvWhgni6@ec2-54-243-190-113.
compute-1.amazonaws.com:5432/dcvgo3fvfmbl44
HEROKU_POSTGRESQL_BLACK_URL: postgres://lskbruwlxcfhuu:JqrcvynZV9e7CzJcOrU43AOXOf@ec2-54-243-190-113.
compute-1.amazonaws.com:5432/dcvgo3fvfmbl44
```

With this fix:

```
[master][~/src/heroku] be bin/heroku pg:credentials --reset black -ahgmnz
Resetting credentials for HEROKU_POSTGRESQL_BLACK_URL (DATABASE_URL)... done
Promoting HEROKU_POSTGRESQL_BLACK_URL (DATABASE_URL)... done
[master][~/src/heroku] be bin/heroku config -ahgmnz                      
=== hgmnz Config Vars
DATABASE_URL:                postgres://nxbghdjtezgwoj:pYTife6b2n5wx2hSL4DqKzOoZg@ec2-54-243-190-113.
compute-1.amazonaws.com:5432/dcvgo3fvfmbl44
HEROKU_POSTGRESQL_BLACK_URL: postgres://nxbghdjtezgwoj:pYTife6b2n5wx2hSL4DqKzOoZg@ec2-54-243-190-113.
compute-1.amazonaws.com:5432/dcvgo3fvfmbl44
```
