### PR TITLE
bump excon/heroku-api to get https proxy fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     heroku (2.33.1)
-      heroku-api (~> 0.3.6)
+      heroku-api (~> 0.3.7)
       launchy (>= 0.3.2)
       netrc (~> 0.7.7)
       rest-client (~> 1.6.1)
@@ -19,12 +19,12 @@ GEM
     builder (3.0.0)
     crack (0.3.1)
     diff-lcs (1.1.3)
-    excon (0.16.8)
+    excon (0.16.10)
     fakefs (0.4.0)
     fpm (0.3.11)
       json
-    heroku-api (0.3.6)
-      excon (~> 0.16.7)
+    heroku-api (0.3.7)
+      excon (~> 0.16.10)
     json (1.6.5)
     launchy (2.1.0)
       addressable (~> 2.2.6)

--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
 
-  gem.add_dependency "heroku-api",  "~> 0.3.6"
+  gem.add_dependency "heroku-api",  "~> 0.3.7"
   gem.add_dependency "netrc",       "~> 0.7.7"
   gem.add_dependency "rest-client", "~> 1.6.1"
   gem.add_dependency "launchy",     ">= 0.3.2"


### PR DESCRIPTION
@ddollar Unfortunately with the last push we got closer on https proxy but we weren't quite there yet. The latest release of excon has been confirmed by a user that was having issues to fix things for them though, so thanks to their help I think we actually have a working excon + https proxy setup (finally).

Details here: https://github.com/geemus/excon/compare/v0.16.8...master

Let me know if you need anything else here or have questions, but hoping this finally closes the long standing issue related to this.
