### PR TITLE
Search more liberally for git host/app name to accomodate heroku_plus and other Heroku account switchers 

### DIFF
--- a/lib/heroku/command/base.rb
+++ b/lib/heroku/command/base.rb
@@ -205,7 +205,7 @@ protected
     return unless File.exists?(".git")
     git("remote -v").split("\n").each do |remote|
       name, url, method = remote.split(/\s/)
-      if url =~ /^git@#{Heroku::Auth.git_host}:([\w\d-]+)\.git$/
+      if url =~ /^git@#{Heroku::Auth.git_host}(?:[\.\w]*):([\w\d-]+)\.git$/
         remotes[name] = $1
       end
     end


### PR DESCRIPTION
I use heroku_plus and I don't want to have to type --app after everything.
The restrictive regex used to detect the current heroku app means that
anytime you change it -- e.g. to add different git hosts in ~/.ssh/config --
--app no longer is autodetected.

Instead, I simply edited the regex a bit to detect (or not; it obviously doesn't
break anything) items like the following:

```
[remote "heroku"]
  url = git@heroku.com.personal:<my app name>.git
```

This way, entries in .ssh/config can read something like this:

```
Host heroku.com.personal
  HostName heroku.com
  ...
```

That, of course, allows using multiple accounts in an unobstrusive way.
The heroku_plus gem could be edited to adopt that convention and we'd no longer need to use the `hp -p` kludge.
