### PR TITLE
myapp ⇒ example

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -14,7 +14,7 @@ require 'heroku/client/ssl_endpoint'
 #
 #   require 'heroku'
 #   heroku = Heroku::Client.new('me@example.com', 'mypass')
-#   heroku.create('myapp')
+#   heroku.create()
 #
 class Heroku::Client
 

--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -177,7 +177,7 @@ module Heroku::Command
     end
 
     def app_addon_url(addon)
-      "https://api.#{heroku.host}/myapps/#{app}/addons/#{addon}"
+      "https://api.#{heroku.host}/apps/#{app}/addons/#{addon}"
     end
 
     def partition_addons(addons)

--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -12,11 +12,11 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   # $ heroku apps
   # === My Apps
-  # myapp1
-  # myapp2
+  # example
+  # example2
   #
   # === Collaborated Apps
-  # theirapp1   other@owner.name
+  # theirapp   other@owner.name
   #
   def index
     validate_arguments!
@@ -51,13 +51,13 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #Examples:
   #
   # $ heroku apps:info
-  # === myapp
-  # Git URL:   git@heroku.com:myapp.git
+  # === example
+  # Git URL:   git@heroku.com:example.git
   # Repo Size: 5M
   # ...
   #
   # $ heroku apps:info --shell
-  # git_url=git@heroku.com:myapp.git
+  # git_url=git@heroku.com:example.git
   # repo_size=5000000
   # ...
   #
@@ -171,12 +171,12 @@ class Heroku::Command::Apps < Heroku::Command::Base
   # http://floating-dragon-42.herokuapp.com/ | git@heroku.com:floating-dragon-42.git
   #
   # # specify a name
-  # $ heroku apps:create myapp
-  # Creating myapp... done, stack is cedar
-  # http://myapp.heroku.com/ | git@heroku.com:myapp.git
+  # $ heroku apps:create example
+  # Creating example... done, stack is cedar
+  # http://example.heroku.com/ | git@heroku.com:example.git
   #
   # # create a staging app
-  # $ heroku apps:create myapp-staging --remote staging
+  # $ heroku apps:create example-staging --remote staging
   #
   def create
     name    = shift_argument || options[:app] || ENV['HEROKU_APP']
@@ -230,8 +230,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   #Example:
   #
-  # $ heroku apps:rename myapp-newname
-  # http://myapp-newname.herokuapp.com/ | git@heroku.com:myapp-newname.git
+  # $ heroku apps:rename example-newname
+  # http://example-newname.herokuapp.com/ | git@heroku.com:example-newname.git
   # Git remote heroku updated
   #
   def rename
@@ -269,7 +269,7 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #Example:
   #
   # $ heroku apps:open
-  # Opening myapp... done
+  # Opening example... done
   #
   def open
     validate_arguments!
@@ -286,8 +286,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
   #
   #Example:
   #
-  # $ heroku apps:destroy -a myapp --confirm myapp
-  # Destroying myapp (including all add-ons)... done
+  # $ heroku apps:destroy -a example --confirm example
+  # Destroying example (including all add-ons)... done
   #
   def destroy
     @app = shift_argument || options[:app] || options[:confirm]

--- a/lib/heroku/command/config.rb
+++ b/lib/heroku/command/config.rb
@@ -46,11 +46,11 @@ class Heroku::Command::Config < Heroku::Command::Base
   #Example:
   #
   # $ heroku config:set A=one
-  # Setting config vars and restarting myapp... done, v123
+  # Setting config vars and restarting example... done, v123
   # A: one
   #
   # $ heroku config:set A=one B=two
-  # Setting config vars and restarting myapp... done, v123
+  # Setting config vars and restarting example... done, v123
   # A: one
   # B: two
   #
@@ -107,11 +107,11 @@ class Heroku::Command::Config < Heroku::Command::Base
   # unset one or more config vars
   #
   # $ heroku config:unset A
-  # Unsetting A and restarting myapp... done, v123
+  # Unsetting A and restarting example... done, v123
   #
   # $ heroku config:unset A B
-  # Unsetting A and restarting myapp... done, v123
-  # Unsetting B and restarting myapp... done, v124
+  # Unsetting A and restarting example... done, v123
+  # Unsetting B and restarting example... done, v124
   #
   def unset
     if args.empty?

--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -13,7 +13,7 @@ module Heroku::Command
     #Examples:
     #
     # $ heroku domains
-    # === Domain names for myapp
+    # === Domain names for example
     # example.com
     #
     def index
@@ -34,7 +34,7 @@ module Heroku::Command
     #Examples:
     #
     # $ heroku domains:add example.com
-    # Adding example.com to myapp... done
+    # Adding example.com to example... done
     #
     def add
       unless domain = shift_argument
@@ -53,7 +53,7 @@ module Heroku::Command
     #Examples:
     #
     # $ heroku domains:remove example.com
-    # Removing example.com from myapp... done
+    # Removing example.com from example... done
     #
     def remove
       unless domain = shift_argument
@@ -72,7 +72,7 @@ module Heroku::Command
     #Examples:
     #
     # $ heroku domains:clear
-    # Removing all domain names for myapp... done
+    # Removing all domain names for example... done
     #
     def clear
       validate_arguments!

--- a/lib/heroku/command/git.rb
+++ b/lib/heroku/command/git.rb
@@ -12,9 +12,9 @@ class Heroku::Command::Git < Heroku::Command::Base
   #
   #Examples:
   #
-  # $ heroku git:clone myapp
-  # Cloning from app 'myapp'...
-  # Cloning into 'myapp'...
+  # $ heroku git:clone example
+  # Cloning from app 'example'...
+  # Cloning into 'example'...
   # remote: Counting objects: 42, done.
   # ...
   #
@@ -43,10 +43,10 @@ class Heroku::Command::Git < Heroku::Command::Base
   #
   #Examples:
   #
-  # $ heroku git:remote -a myapp
+  # $ heroku git:remote -a example
   # Git remote heroku added
   #
-  # $ heroku git:remote -a myapp
+  # $ heroku git:remote -a example
   # !    Git remote heroku already exists
   #
   def remote

--- a/lib/heroku/command/labs.rb
+++ b/lib/heroku/command/labs.rb
@@ -15,7 +15,7 @@ class Heroku::Command::Labs < Heroku::Command::Base
   #
   # === App Features (glacial-retreat-5913)
   # [ ] preboot            Provide seamless web dyno deploys
-  # [ ] user-env-compile   Add user config vars to the environment during slug compilation  # $ heroku labs -a myapp
+  # [ ] user-env-compile   Add user config vars to the environment during slug compilation  # $ heroku labs -a example
   #
   def index
     validate_arguments!

--- a/lib/heroku/command/maintenance.rb
+++ b/lib/heroku/command/maintenance.rb
@@ -31,7 +31,7 @@ class Heroku::Command::Maintenance < Heroku::Command::Base
   #Example:
   #
   # $ heroku maintenance:on
-  # Enabling maintenance mode for myapp
+  # Enabling maintenance mode for example
   #
   def on
     validate_arguments!
@@ -48,7 +48,7 @@ class Heroku::Command::Maintenance < Heroku::Command::Base
   #Example:
   #
   # $ heroku maintenance:off
-  # Disabling maintenance mode for myapp
+  # Disabling maintenance mode for example
   #
   def off
     validate_arguments!

--- a/lib/heroku/command/releases.rb
+++ b/lib/heroku/command/releases.rb
@@ -11,7 +11,7 @@ class Heroku::Command::Releases < Heroku::Command::Base
   #Example:
   #
   # $ heroku releases
-  # === myapp Releases
+  # === example Releases
   # v1 Config add FOO_BAR by email@example.com 0s ago
   # v2 Config add BAR_BAZ by email@example.com 0s ago
   # v3 Config add BAZ_QUX by email@example.com 0s ago
@@ -105,10 +105,10 @@ class Heroku::Command::Releases < Heroku::Command::Base
   #Example:
   #
   # $ heroku releases:rollback
-  # Rolling back myapp... done, v122
+  # Rolling back example... done, v122
   #
   # $ heroku releases:rollback v42
-  # Rolling back myapp to v42... done
+  # Rolling back example to v42... done
   #
   def rollback
     release = shift_argument

--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -76,7 +76,7 @@ class Heroku::Command::Run < Heroku::Command::Base
   #Examples:
   #
   # $ heroku console
-  # Ruby console for myapp.heroku.com
+  # Ruby console for example.heroku.com
   # >>
   #
   def console

--- a/lib/heroku/command/sharing.rb
+++ b/lib/heroku/command/sharing.rb
@@ -13,7 +13,7 @@ module Heroku::Command
     #Example:
     #
     # $ heroku sharing
-    # === myapp Collaborators
+    # === example Collaborators
     # collaborator@example.com
     # email@example.com
     #
@@ -33,7 +33,7 @@ module Heroku::Command
     #Example:
     #
     # $ heroku sharing:add collaborator@example.com
-    # Adding collaborator@example.com to myapp collaborators... done
+    # Adding collaborator@example.com to example collaborators... done
     #
     def add
       unless email = shift_argument
@@ -53,7 +53,7 @@ module Heroku::Command
     #Example:
     #
     # $ heroku sharing:remove collaborator@example.com
-    # Removing collaborator@example.com to myapp collaborators... done
+    # Removing collaborator@example.com to example collaborators... done
     #
     def remove
       unless email = shift_argument
@@ -73,7 +73,7 @@ module Heroku::Command
     #Example:
     #
     # $ heroku sharing:transfer collaborator@example.com
-    # Transferring myapp to collaborator@example.com... done
+    # Transferring example to collaborator@example.com... done
     #
     def transfer
       unless email = shift_argument

--- a/lib/heroku/command/stack.rb
+++ b/lib/heroku/command/stack.rb
@@ -12,7 +12,7 @@ module Heroku::Command
     #Example:
     #
     # $ heroku stack
-    # === myapp Available Stacks
+    # === example Available Stacks
     #   bamboo-mri-1.9.2
     #   bamboo-ree-1.8.7
     # * cedar

--- a/spec/heroku/client/ssl_endpoint_spec.rb
+++ b/spec/heroku/client/ssl_endpoint_spec.rb
@@ -7,42 +7,42 @@ describe Heroku::Client, "ssl endpoints" do
   end
 
   it "adds an ssl endpoint" do
-    stub_request(:post, "https://api.heroku.com/apps/myapp/ssl-endpoints").
+    stub_request(:post, "https://api.heroku.com/apps/example/ssl-endpoints").
       with(:body => { :accept => "json", :pem => "pem content", :key => "key content" }).
       to_return(:body => %{ {"cname": "tokyo-1050" } })
-    @client.ssl_endpoint_add("myapp", "pem content", "key content").should == { "cname" => "tokyo-1050" }
+    @client.ssl_endpoint_add("example", "pem content", "key content").should == { "cname" => "tokyo-1050" }
   end
 
   it "gets info on an ssl endpoint" do
-    stub_request(:get, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050").
+    stub_request(:get, "https://api.heroku.com/apps/example/ssl-endpoints/tokyo-1050").
       to_return(:body => %{ {"cname": "tokyo-1050" } })
-    @client.ssl_endpoint_info("myapp", "tokyo-1050").should == { "cname" => "tokyo-1050" }
+    @client.ssl_endpoint_info("example", "tokyo-1050").should == { "cname" => "tokyo-1050" }
   end
 
   it "lists ssl endpoints for an app" do
-    stub_request(:get, "https://api.heroku.com/apps/myapp/ssl-endpoints").
+    stub_request(:get, "https://api.heroku.com/apps/example/ssl-endpoints").
       to_return(:body => %{ [{"cname": "tokyo-1050" }, {"cname": "tokyo-1051" }] })
-    @client.ssl_endpoint_list("myapp").should == [
+    @client.ssl_endpoint_list("example").should == [
       { "cname" => "tokyo-1050" },
       { "cname" => "tokyo-1051" },
     ]
   end
 
   it "removes an ssl endpoint" do
-    stub_request(:delete, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050")
-    @client.ssl_endpoint_remove("myapp", "tokyo-1050")
+    stub_request(:delete, "https://api.heroku.com/apps/example/ssl-endpoints/tokyo-1050")
+    @client.ssl_endpoint_remove("example", "tokyo-1050")
   end
 
   it "rolls back an ssl endpoint" do
-    stub_request(:post, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050/rollback").
+    stub_request(:post, "https://api.heroku.com/apps/example/ssl-endpoints/tokyo-1050/rollback").
       to_return(:body => %{ {"cname": "tokyo-1050" } })
-    @client.ssl_endpoint_rollback("myapp", "tokyo-1050").should == { "cname" => "tokyo-1050" }
+    @client.ssl_endpoint_rollback("example", "tokyo-1050").should == { "cname" => "tokyo-1050" }
   end
 
   it "updates an ssl endpoint" do
-    stub_request(:put, "https://api.heroku.com/apps/myapp/ssl-endpoints/tokyo-1050").
+    stub_request(:put, "https://api.heroku.com/apps/example/ssl-endpoints/tokyo-1050").
       with(:body => { :accept => "json", :pem => "pem content", :key => "key content" }).
       to_return(:body => %{ {"cname": "tokyo-1050" } })
-    @client.ssl_endpoint_update("myapp", "tokyo-1050", "pem content", "key content").should == { "cname" => "tokyo-1050" }
+    @client.ssl_endpoint_update("example", "tokyo-1050", "pem content", "key content").should == { "cname" => "tokyo-1050" }
   end
 end

--- a/spec/heroku/client_spec.rb
+++ b/spec/heroku/client_spec.rb
@@ -24,26 +24,26 @@ describe Heroku::Client do
     stub_api_request(:get, "/apps").to_return(:body => <<-EOXML)
       <?xml version='1.0' encoding='UTF-8'?>
       <apps type="array">
-        <app><name>myapp1</name><owner>test@heroku.com</owner></app>
-        <app><name>myapp2</name><owner>test@heroku.com</owner></app>
+        <app><name>example</name><owner>test@heroku.com</owner></app>
+        <app><name>example2</name><owner>test@heroku.com</owner></app>
       </apps>
     EOXML
     capture_stderr do # capture deprecation message
       @client.list.should == [
-        ["myapp1", "test@heroku.com"],
-        ["myapp2", "test@heroku.com"]
+        ["example", "test@heroku.com"],
+        ["example2", "test@heroku.com"]
       ]
     end
   end
 
   it "info -> get app attributes" do
-    stub_api_request(:get, "/apps/myapp").to_return(:body => <<-EOXML)
+    stub_api_request(:get, "/apps/example").to_return(:body => <<-EOXML)
       <?xml version='1.0' encoding='UTF-8'?>
       <app>
         <blessed type='boolean'>true</blessed>
         <created-at type='datetime'>2008-07-08T17:21:50-07:00</created-at>
         <id type='integer'>49134</id>
-        <name>myapp</name>
+        <name>example</name>
         <production type='boolean'>true</production>
         <share-public type='boolean'>true</share-public>
         <domain_name/>
@@ -52,7 +52,7 @@ describe Heroku::Client do
     @client.stub!(:list_collaborators).and_return([:jon, :mike])
     @client.stub!(:installed_addons).and_return([:addon1])
     capture_stderr do # capture deprecation message
-      @client.info('myapp').should == { :blessed => 'true', :created_at => '2008-07-08T17:21:50-07:00', :id => '49134', :name => 'myapp', :production => 'true', :share_public => 'true', :domain_name => nil, :collaborators => [:jon, :mike], :addons => [:addon1] }
+      @client.info('example').should == { :blessed => 'true', :created_at => '2008-07-08T17:21:50-07:00', :id => '49134', :name => 'example', :production => 'true', :share_public => 'true', :domain_name => nil, :collaborators => [:jon, :mike], :addons => [:addon1] }
     end
   end
 
@@ -82,14 +82,14 @@ describe Heroku::Client do
     @client.should_receive(:resource).and_return(@resource)
     @resource.should_receive(:put).with({}, @client.heroku_headers).and_return(@response)
     capture_stderr do # capture deprecation message
-      @client.create_complete?('myapp').should be_false
+      @client.create_complete?('example').should be_false
     end
   end
 
   it "update(name, attributes) -> updates existing apps" do
-    stub_api_request(:put, "/apps/myapp").with(:body => "app[mode]=production")
+    stub_api_request(:put, "/apps/example").with(:body => "app[mode]=production")
     capture_stderr do # capture deprecation message
-      @client.update("myapp", :mode => 'production')
+      @client.update("example", :mode => 'production')
     end
   end
 
@@ -101,63 +101,63 @@ describe Heroku::Client do
   end
 
   it "rake(app_name, cmd) -> run a rake command on the app" do
-    stub_api_request(:post, "/apps/myapp/services").with(:body => "rake db:migrate").to_return(:body => "foo")
+    stub_api_request(:post, "/apps/example/services").with(:body => "rake db:migrate").to_return(:body => "foo")
     stub_api_request(:get,  "/foo").to_return(:body => "output")
     capture_stderr do # capture deprecation message
-      @client.rake('myapp', 'db:migrate')
+      @client.rake('example', 'db:migrate')
     end
   end
 
   it "console(app_name, cmd) -> run a console command on the app" do
-    stub_api_request(:post, "/apps/myapp/console").with(:body => "command=2%2B2")
-    @client.console('myapp', '2+2')
+    stub_api_request(:post, "/apps/example/console").with(:body => "command=2%2B2")
+    @client.console('example', '2+2')
   end
 
   it "console(app_name) { |c| } -> opens a console session, yields one accessor and closes it after the block" do
-    stub_api_request(:post,   "/apps/myapp/consoles").to_return(:body => "consolename")
-    stub_api_request(:post,   "/apps/myapp/consoles/consolename/command").with(:body => "command=1%2B1").to_return(:body => "2")
-    stub_api_request(:delete, "/apps/myapp/consoles/consolename")
+    stub_api_request(:post,   "/apps/example/consoles").to_return(:body => "consolename")
+    stub_api_request(:post,   "/apps/example/consoles/consolename/command").with(:body => "command=1%2B1").to_return(:body => "2")
+    stub_api_request(:delete, "/apps/example/consoles/consolename")
 
-    @client.console('myapp') do |c|
+    @client.console('example') do |c|
       c.run("1+1").should == '=> 2'
     end
   end
 
   it "shows an error message when a console request fails" do
-    stub_request(:post, %r{.*/apps/myapp/console}).to_return({
+    stub_request(:post, %r{.*/apps/example/console}).to_return({
       :body => "ERRMSG", :status => 502
     })
-    lambda { @client.console('myapp') }.should raise_error(Heroku::Client::AppCrashed, /Your application may have crashed/)
+    lambda { @client.console('example') }.should raise_error(Heroku::Client::AppCrashed, /Your application may have crashed/)
   end
 
   it "restart(app_name) -> restarts the app servers" do
-    stub_api_request(:delete, "/apps/myapp/server")
+    stub_api_request(:delete, "/apps/example/server")
     capture_stderr do # capture deprecation message
-      @client.restart('myapp')
+      @client.restart('example')
     end
   end
 
   describe "read_logs" do
     describe "old style" do
       before(:each) do
-        stub_api_request(:get, "/apps/myapp/logs?logplex=true").to_return(:body => "Use old logs")
-        stub_api_request(:get, "/apps/myapp/logs").to_return(:body => "oldlogs")
+        stub_api_request(:get, "/apps/example/logs?logplex=true").to_return(:body => "Use old logs")
+        stub_api_request(:get, "/apps/example/logs").to_return(:body => "oldlogs")
       end
 
       it "can read old style logs" do
         @client.should_receive(:puts).with("oldlogs")
-        @client.read_logs("myapp")
+        @client.read_logs("example")
       end
     end
 
     describe "new style" do
       before(:each) do
-        stub_api_request(:get, "/apps/myapp/logs?logplex=true").to_return(:body => "https://logplex.heroku.com/identifier")
+        stub_api_request(:get, "/apps/example/logs?logplex=true").to_return(:body => "https://logplex.heroku.com/identifier")
         stub_request(:get, "https://logplex.heroku.com/identifier").to_return(:body => "newlogs")
       end
 
       it "can read new style logs" do
-        @client.read_logs("myapp") do |logs|
+        @client.read_logs("example") do |logs|
           logs.should == "newlogs"
         end
       end
@@ -165,40 +165,40 @@ describe Heroku::Client do
   end
 
   it "logs(app_name) -> returns recent output of the app logs" do
-    stub_api_request(:get, "/apps/myapp/logs").to_return(:body => "log")
+    stub_api_request(:get, "/apps/example/logs").to_return(:body => "log")
     capture_stderr do # capture deprecation message
-      @client.logs('myapp').should == 'log'
+      @client.logs('example').should == 'log'
     end
   end
 
   it "can get the number of dynos" do
-    stub_api_request(:get, "/apps/myapp").to_return(:body => <<-EOXML)
+    stub_api_request(:get, "/apps/example").to_return(:body => <<-EOXML)
       <?xml version='1.0' encoding='UTF-8'?>
       <app>
         <dynos type='integer'>5</dynos>
       </app>
     EOXML
     capture_stderr do # capture deprecation message
-      @client.dynos('myapp').should == 5
+      @client.dynos('example').should == 5
     end
   end
 
   it "can get the number of workers" do
-    stub_api_request(:get, "/apps/myapp").to_return(:body => <<-EOXML)
+    stub_api_request(:get, "/apps/example").to_return(:body => <<-EOXML)
       <?xml version='1.0' encoding='UTF-8'?>
       <app>
         <workers type='integer'>5</workers>
       </app>
     EOXML
     capture_stderr do # capture deprecation message
-      @client.workers('myapp').should == 5
+      @client.workers('example').should == 5
     end
   end
 
   it "set_dynos(app_name, qty) -> scales the app" do
-    stub_api_request(:put, "/apps/myapp/dynos").with(:body => "dynos=3")
+    stub_api_request(:put, "/apps/example/dynos").with(:body => "dynos=3")
     capture_stderr do # capture deprecation message
-      @client.set_dynos('myapp', 3)
+      @client.set_dynos('example', 3)
     end
   end
 
@@ -208,7 +208,7 @@ describe Heroku::Client do
     e.stub!(:http_body).and_return('the crashlog')
     @client.should_receive(:post).and_raise(e)
     capture_stderr do # capture deprecation message
-      lambda { @client.rake('myapp', '') }.should raise_error(Heroku::Client::AppCrashed)
+      lambda { @client.rake('example', '') }.should raise_error(Heroku::Client::AppCrashed)
     end
   end
 
@@ -218,22 +218,22 @@ describe Heroku::Client do
     e.stub!(:http_body).and_return('not a crashlog')
     @client.should_receive(:post).and_raise(e)
     capture_stderr do # capture deprecation message
-      lambda { @client.rake('myapp', '') }.should raise_error(RestClient::RequestFailed)
+      lambda { @client.rake('example', '') }.should raise_error(RestClient::RequestFailed)
     end
   end
 
   describe "ps_scale" do
     it "scales a process and returns the new count" do
-      stub_api_request(:post, "/apps/myapp/ps/scale").with(:body => { :type => "web", :qty => "5" }).to_return(:body => "5")
+      stub_api_request(:post, "/apps/example/ps/scale").with(:body => { :type => "web", :qty => "5" }).to_return(:body => "5")
       capture_stderr do # capture deprecation message
-        @client.ps_scale("myapp", :type => "web", :qty => "5").should == 5
+        @client.ps_scale("example", :type => "web", :qty => "5").should == 5
       end
     end
   end
 
   describe "collaborators" do
     it "list(app_name) -> list app collaborators" do
-      stub_api_request(:get, "/apps/myapp/collaborators").to_return(:body => <<-EOXML)
+      stub_api_request(:get, "/apps/example/collaborators").to_return(:body => <<-EOXML)
         <?xml version="1.0" encoding="UTF-8"?>
         <collaborators type="array">
           <collaborator><email>joe@example.com</email></collaborator>
@@ -241,7 +241,7 @@ describe Heroku::Client do
         </collaborators>
       EOXML
       capture_stderr do # capture deprecation message
-        @client.list_collaborators('myapp').should == [
+        @client.list_collaborators('example').should == [
           { :email => 'joe@example.com' },
           { :email => 'jon@example.com' }
         ]
@@ -249,23 +249,23 @@ describe Heroku::Client do
     end
 
     it "add_collaborator(app_name, email) -> adds collaborator to app" do
-      stub_api_request(:post, "/apps/myapp/collaborators").with(:body => "collaborator%5Bemail%5D=joe%40example.com")
+      stub_api_request(:post, "/apps/example/collaborators").with(:body => "collaborator%5Bemail%5D=joe%40example.com")
       capture_stderr do # capture deprecation message
-        @client.add_collaborator('myapp', 'joe@example.com')
+        @client.add_collaborator('example', 'joe@example.com')
       end
     end
 
     it "remove_collaborator(app_name, email) -> removes collaborator from app" do
-      stub_api_request(:delete, "/apps/myapp/collaborators/joe%40example%2Ecom")
+      stub_api_request(:delete, "/apps/example/collaborators/joe%40example%2Ecom")
       capture_stderr do # capture deprecation message
-        @client.remove_collaborator('myapp', 'joe@example.com')
+        @client.remove_collaborator('example', 'joe@example.com')
       end
     end
   end
 
   describe "domain names" do
     it "list(app_name) -> list app domain names" do
-      stub_api_request(:get, "/apps/myapp/domains").to_return(:body => <<-EOXML)
+      stub_api_request(:get, "/apps/example/domains").to_return(:body => <<-EOXML)
         <?xml version="1.0" encoding="UTF-8"?>
         <domain-names type="array">
           <domain-name><domain>example1.com</domain></domain-name>
@@ -273,51 +273,51 @@ describe Heroku::Client do
         </domain-names>
       EOXML
       capture_stderr do # capture deprecation message
-        @client.list_domains('myapp').should == [{:domain => 'example1.com'}, {:domain => 'example2.com'}]
+        @client.list_domains('example').should == [{:domain => 'example1.com'}, {:domain => 'example2.com'}]
       end
     end
 
     it "add_domain(app_name, domain) -> adds domain name to app" do
-      stub_api_request(:post, "/apps/myapp/domains").with(:body => "example.com")
+      stub_api_request(:post, "/apps/example/domains").with(:body => "example.com")
       capture_stderr do # capture deprecation message
-        @client.add_domain('myapp', 'example.com')
+        @client.add_domain('example', 'example.com')
       end
     end
 
     it "remove_domain(app_name, domain) -> removes domain name from app" do
-      stub_api_request(:delete, "/apps/myapp/domains/example.com")
+      stub_api_request(:delete, "/apps/example/domains/example.com")
       capture_stderr do # capture deprecation message
-        @client.remove_domain('myapp', 'example.com')
+        @client.remove_domain('example', 'example.com')
       end
     end
 
     it "remove_domain(app_name, domain) -> makes sure a domain is set" do
       lambda do
         capture_stderr do # capture deprecation message
-          @client.remove_domain('myapp', '')
+          @client.remove_domain('example', '')
         end
       end.should raise_error(ArgumentError)
     end
 
     it "remove_domains(app_name) -> removes all domain names from app" do
-      stub_api_request(:delete, "/apps/myapp/domains")
+      stub_api_request(:delete, "/apps/example/domains")
       capture_stderr do # capture deprecation message
-        @client.remove_domains('myapp')
+        @client.remove_domains('example')
       end
     end
 
     it "add_ssl(app_name, pem, key) -> adds a ssl cert to the domain" do
-      stub_api_request(:post, "/apps/myapp/ssl").with do |request|
+      stub_api_request(:post, "/apps/example/ssl").with do |request|
         body = CGI::parse(request.body)
         body["key"].first.should == "thekey"
         body["pem"].first.should == "thepem"
       end.to_return(:body => "{}")
-      @client.add_ssl('myapp', 'thepem', 'thekey')
+      @client.add_ssl('example', 'thepem', 'thekey')
     end
 
     it "remove_ssl(app_name, domain) -> removes the ssl cert for the domain" do
-      stub_api_request(:delete, "/apps/myapp/domains/example.com/ssl")
-      @client.remove_ssl('myapp', 'example.com')
+      stub_api_request(:delete, "/apps/example/domains/example.com/ssl")
+      @client.remove_ssl('example', 'example.com')
     end
   end
 
@@ -364,63 +364,63 @@ describe Heroku::Client do
         end
       end
 
-      stub_api_request(:post, "/apps/myapp/database/session2").to_return(:body => "{\"session_id\":\"x234\"}")
-      @client.database_session('myapp')
+      stub_api_request(:post, "/apps/example/database/session2").to_return(:body => "{\"session_id\":\"x234\"}")
+      @client.database_session('example')
     end
 
     it "database_reset(app_name) -> reset an app's database" do
-      stub_api_request(:post, "/apps/myapp/database/reset")
-      @client.database_reset('myapp')
+      stub_api_request(:post, "/apps/example/database/reset")
+      @client.database_reset('example')
     end
 
     it "maintenance(app_name, :on) -> sets maintenance mode for an app" do
-      stub_api_request(:post, "/apps/myapp/server/maintenance").with(:body => "maintenance_mode=1")
+      stub_api_request(:post, "/apps/example/server/maintenance").with(:body => "maintenance_mode=1")
       capture_stderr do # capture deprecation message
-        @client.maintenance('myapp', :on)
+        @client.maintenance('example', :on)
       end
     end
 
     it "maintenance(app_name, :off) -> turns off maintenance mode for an app" do
-      stub_api_request(:post, "/apps/myapp/server/maintenance").with(:body => "maintenance_mode=0")
+      stub_api_request(:post, "/apps/example/server/maintenance").with(:body => "maintenance_mode=0")
       capture_stderr do # capture deprecation message
-        @client.maintenance('myapp', :off)
+        @client.maintenance('example', :off)
       end
     end
   end
 
   describe "config vars" do
     it "config_vars(app_name) -> json hash of config vars for the app" do
-      stub_api_request(:get, "/apps/myapp/config_vars").to_return(:body => '{"A":"one", "B":"two"}')
+      stub_api_request(:get, "/apps/example/config_vars").to_return(:body => '{"A":"one", "B":"two"}')
       capture_stderr do # capture deprecation message
-        @client.config_vars('myapp').should == { 'A' => 'one', 'B' => 'two'}
+        @client.config_vars('example').should == { 'A' => 'one', 'B' => 'two'}
       end
     end
 
     it "add_config_vars(app_name, vars)" do
-      stub_api_request(:put, "/apps/myapp/config_vars").with(:body => '{"x":"y"}')
+      stub_api_request(:put, "/apps/example/config_vars").with(:body => '{"x":"y"}')
       capture_stderr do # capture deprecation message
-        @client.add_config_vars('myapp', {'x'=> 'y'})
+        @client.add_config_vars('example', {'x'=> 'y'})
       end
     end
 
     it "remove_config_var(app_name, key)" do
-      stub_api_request(:delete, "/apps/myapp/config_vars/mykey")
+      stub_api_request(:delete, "/apps/example/config_vars/mykey")
       capture_stderr do # capture deprecation message
-        @client.remove_config_var('myapp', 'mykey')
+        @client.remove_config_var('example', 'mykey')
       end
     end
 
     it "clear_config_vars(app_name) -> resets all config vars for this app" do
-      stub_api_request(:delete, "/apps/myapp/config_vars")
+      stub_api_request(:delete, "/apps/example/config_vars")
       capture_stderr do # capture deprecation message
-        @client.clear_config_vars('myapp')
+        @client.clear_config_vars('example')
       end
     end
 
     it "can handle config vars with special characters" do
-      stub_api_request(:delete, "/apps/myapp/config_vars/foo%5Bbar%5D")
+      stub_api_request(:delete, "/apps/example/config_vars/foo%5Bbar%5D")
       capture_stderr do # capture deprecation message
-        lambda { @client.remove_config_var('myapp', 'foo[bar]') }.should_not raise_error
+        lambda { @client.remove_config_var('example', 'foo[bar]') }.should_not raise_error
       end
     end
   end
@@ -432,68 +432,68 @@ describe Heroku::Client do
     end
 
     it "installed_addons(app_name) -> array of installed addons" do
-      stub_api_request(:get, "/apps/myapp/addons").to_return(:body => '[{"name":"addon1"}]')
-      @client.installed_addons('myapp').should == [{'name' => 'addon1'}]
+      stub_api_request(:get, "/apps/example/addons").to_return(:body => '[{"name":"addon1"}]')
+      @client.installed_addons('example').should == [{'name' => 'addon1'}]
     end
 
     it "install_addon(app_name, addon_name)" do
-      stub_api_request(:post, "/apps/myapp/addons/addon1")
-      @client.install_addon('myapp', 'addon1').should be_nil
+      stub_api_request(:post, "/apps/example/addons/addon1")
+      @client.install_addon('example', 'addon1').should be_nil
     end
 
     it "upgrade_addon(app_name, addon_name)" do
-      stub_api_request(:put, "/apps/myapp/addons/addon1")
-      @client.upgrade_addon('myapp', 'addon1').should be_nil
+      stub_api_request(:put, "/apps/example/addons/addon1")
+      @client.upgrade_addon('example', 'addon1').should be_nil
     end
 
     it "downgrade_addon(app_name, addon_name)" do
-      stub_api_request(:put, "/apps/myapp/addons/addon1")
-      @client.downgrade_addon('myapp', 'addon1').should be_nil
+      stub_api_request(:put, "/apps/example/addons/addon1")
+      @client.downgrade_addon('example', 'addon1').should be_nil
     end
 
     it "uninstall_addon(app_name, addon_name)" do
-      stub_api_request(:delete, "/apps/myapp/addons/addon1?").
+      stub_api_request(:delete, "/apps/example/addons/addon1?").
         to_return(:body => json_encode({"message" => nil, "price" => "free", "status" => "uninstalled"}))
 
-      @client.uninstall_addon('myapp', 'addon1').should be_true
+      @client.uninstall_addon('example', 'addon1').should be_true
     end
 
     it "uninstall_addon(app_name, addon_name) with confirmation" do
-      stub_api_request(:delete, "/apps/myapp/addons/addon1?confirm=myapp").
+      stub_api_request(:delete, "/apps/example/addons/addon1?confirm=example").
         to_return(:body => json_encode({"message" => nil, "price" => "free", "status" => "uninstalled"}))
 
-      @client.uninstall_addon('myapp', 'addon1', :confirm => "myapp").should be_true
+      @client.uninstall_addon('example', 'addon1', :confirm => "example").should be_true
     end
 
     it "install_addon(app_name, addon_name) with response" do
-      stub_request(:post, "https://api.heroku.com/apps/myapp/addons/addon1").
+      stub_request(:post, "https://api.heroku.com/apps/example/addons/addon1").
         to_return(:body => json_encode({'price' => 'free', 'message' => "Don't Panic"}))
 
-      @client.install_addon('myapp', 'addon1').
+      @client.install_addon('example', 'addon1').
         should == { 'price' => 'free', 'message' => "Don't Panic" }
     end
 
     it "upgrade_addon(app_name, addon_name) with response" do
-      stub_request(:put, "https://api.heroku.com/apps/myapp/addons/addon1").
+      stub_request(:put, "https://api.heroku.com/apps/example/addons/addon1").
         to_return(:body => json_encode('price' => 'free', 'message' => "Don't Panic"))
 
-      @client.upgrade_addon('myapp', 'addon1').
+      @client.upgrade_addon('example', 'addon1').
         should == { 'price' => 'free', 'message' => "Don't Panic" }
     end
 
     it "downgrade_addon(app_name, addon_name) with response" do
-      stub_request(:put, "https://api.heroku.com/apps/myapp/addons/addon1").
+      stub_request(:put, "https://api.heroku.com/apps/example/addons/addon1").
         to_return(:body => json_encode('price' => 'free', 'message' => "Don't Panic"))
 
-      @client.downgrade_addon('myapp', 'addon1').
+      @client.downgrade_addon('example', 'addon1').
         should == { 'price' => 'free', 'message' => "Don't Panic" }
     end
 
     it "uninstall_addon(app_name, addon_name) with response" do
-      stub_api_request(:delete, "/apps/myapp/addons/addon1?").
+      stub_api_request(:delete, "/apps/example/addons/addon1?").
         to_return(:body => json_encode('price'=> 'free', 'message'=> "Don't Panic"))
 
-      @client.uninstall_addon('myapp', 'addon1').
+      @client.uninstall_addon('example', 'addon1').
         should == { 'price' => 'free', 'message' => "Don't Panic" }
     end
   end
@@ -548,16 +548,16 @@ describe Heroku::Client do
 
   describe "stacks" do
     it "list_stacks(app_name) -> json hash of available stacks" do
-      stub_api_request(:get, "/apps/myapp/stack?include_deprecated=false").to_return(:body => '{"stack":"one"}')
+      stub_api_request(:get, "/apps/example/stack?include_deprecated=false").to_return(:body => '{"stack":"one"}')
       capture_stderr do # capture deprecation message
-        @client.list_stacks("myapp").should == { 'stack' => 'one' }
+        @client.list_stacks("example").should == { 'stack' => 'one' }
       end
     end
 
     it "list_stacks(app_name, include_deprecated=true) passes the deprecated option" do
-      stub_api_request(:get, "/apps/myapp/stack?include_deprecated=true").to_return(:body => '{"stack":"one"}')
+      stub_api_request(:get, "/apps/example/stack?include_deprecated=true").to_return(:body => '{"stack":"one"}')
       capture_stderr do # capture deprecation message
-        @client.list_stacks("myapp", :include_deprecated => true).should == { 'stack' => 'one' }
+        @client.list_stacks("example", :include_deprecated => true).should == { 'stack' => 'one' }
       end
     end
   end

--- a/spec/heroku/command/addons_spec.rb
+++ b/spec/heroku/command/addons_spec.rb
@@ -5,25 +5,25 @@ module Heroku::Command
   describe Addons do
     before do
       @addons = prepare_command(Addons)
-      stub_core.release("myapp", "current").returns( "name" => "v99" )
+      stub_core.release("example", "current").returns( "name" => "v99" )
     end
 
     describe "index" do
 
       before(:each) do
         stub_core
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "should display no addons when none are configured" do
         stderr, stdout = execute("addons")
         stderr.should == ""
         stdout.should == <<-STDOUT
-myapp has no add-ons.
+example has no add-ons.
 STDOUT
       end
 
@@ -32,7 +32,7 @@ STDOUT
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/addons$}
+            :path => %r{^/apps/example/addons$}
           },
           {
             :body   => Heroku::API::OkJson.encode([
@@ -46,12 +46,12 @@ STDOUT
         stderr, stdout = execute("addons")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp Configured Add-ons
+=== example Configured Add-ons
 deployhooks:http
 heroku-postgresql:ronin  HEROKU_POSTGRESQL_RED
 
-=== myapp Add-ons to Configure
-deployhooks:email  https://api.heroku.com/myapps/myapp/addons/deployhooks:email
+=== example Add-ons to Configure
+deployhooks:email  https://api.heroku.com/apps/example/addons/deployhooks:email
 
 STDOUT
         Excon.stubs.shift
@@ -93,19 +93,19 @@ STDOUT
     describe 'v1-style command line params' do
       it "understands foo=baz" do
         @addons.stub!(:args).and_return(%w(my_addon foo=baz))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => 'baz' })
         @addons.add
       end
 
       it "gives a deprecation notice with an example" do
-        stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+        stub_request(:post, %r{apps/example/addons/my_addon$}).
           with(:body => {:config => {:foo => 'bar', :extra => "XXX"}}).
           to_return(:body => Heroku::OkJson.encode({ 'price' => 'free' }))
         Excon.stub(
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/releases/current}
+            :path => %r{^/apps/example/releases/current}
           },
           {
             :body   => Heroku::API::OkJson.encode({ 'name' => 'v99' }),
@@ -116,7 +116,7 @@ STDOUT
         stderr.should == ""
         stdout.should == <<-STDOUT
 Warning: non-unix style params have been deprecated, use --extra=XXX instead
-Adding my_addon on myapp... done, v99 (free)
+Adding my_addon on example... done, v99 (free)
 Use `heroku addons:docs my_addon` to view documentation.
 STDOUT
         Excon.stubs.shift
@@ -126,36 +126,36 @@ STDOUT
     describe 'unix-style command line params' do
       it "understands --foo=baz" do
         @addons.stub!(:args).and_return(%w(my_addon --foo=baz))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => 'baz' })
         @addons.add
       end
 
       it "understands --foo baz" do
         @addons.stub!(:args).and_return(%w(my_addon --foo baz))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => 'baz' })
         @addons.add
       end
 
       it "treats lone switches as true" do
         @addons.stub!(:args).and_return(%w(my_addon --foo))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => true })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => true })
         @addons.add
       end
 
       it "converts 'true' to boolean" do
         @addons.stub!(:args).and_return(%w(my_addon --foo=true))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => true })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => true })
         @addons.add
       end
 
       it "works with many config vars" do
         @addons.stub!(:args).and_return(%w(my_addon --foo  baz --bar  yes --baz=foo --bab --bob=true))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz', 'bar' => 'yes', 'baz' => 'foo', 'bab' => true, 'bob' => true })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => 'baz', 'bar' => 'yes', 'baz' => 'foo', 'bab' => true, 'bob' => true })
         @addons.add
       end
 
       it "sends the variables to the server" do
-        stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+        stub_request(:post, %r{apps/example/addons/my_addon$}).
           with(:body => {:config => { 'foo' => 'baz', 'bar' => 'yes', 'baz' => 'foo', 'bab' => 'true', 'bob' => 'true' }})
         stderr, stdout = execute("addons:add my_addon --foo  baz --bar  yes --baz=foo --bab --bob=true")
         stderr.should == ""
@@ -170,12 +170,12 @@ STDOUT
     describe "mixed options" do
       it "understands foo=bar and --baz=bar on the same line" do
         @addons.stub!(:args).and_return(%w(my_addon foo=baz --baz=bar bob=true --bar))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', { 'foo' => 'baz', 'baz' => 'bar', 'bar' => true, 'bob' => true })
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', { 'foo' => 'baz', 'baz' => 'bar', 'bar' => true, 'bob' => true })
         @addons.add
       end
 
       it "sends the variables to the server" do
-        stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+        stub_request(:post, %r{apps/example/addons/my_addon$}).
           with(:body => {:config => { 'foo' => 'baz', 'baz' => 'bar', 'bar' => 'true', 'bob' => 'true' }})
         stderr, stdout = execute("addons:add my_addon foo=baz --baz=bar bob=true --bar")
         stderr.should == ""
@@ -188,7 +188,7 @@ STDOUT
         %w{fork follow}.each do |switch|
           @addons.stub!(:args).and_return("addon --#{switch} HEROKU_POSTGRESQL_RED".split)
           @addons.heroku.should_receive(:install_addon).
-            with('myapp', 'addon', {switch => 'HEROKU_POSTGRESQL_RED'})
+            with('example', 'addon', {switch => 'HEROKU_POSTGRESQL_RED'})
           @addons.add
         end
       end
@@ -203,7 +203,7 @@ STDOUT
                              'type'  => 'heroku-postgresql:ronin' }})
           ])
           @addons.stub!(:args).and_return("heroku-postgresql --#{switch} HEROKU_POSTGRESQL_RED".split)
-          @addons.heroku.should_receive(:install_addon).with('myapp', 'heroku-postgresql', {switch => 'postgres://red_url'})
+          @addons.heroku.should_receive(:install_addon).with('example', 'heroku-postgresql', {switch => 'postgres://red_url'})
           @addons.add
         end
       end
@@ -213,7 +213,7 @@ STDOUT
           @addons.stub!(:app_config_vars).and_return({})
           @addons.stub!(:app_attachments).and_return([])
           @addons.stub!(:args).and_return("heroku-postgresql --#{switch} postgres://foo:yeah@awesome.com:234/bestdb".split)
-          @addons.heroku.should_receive(:install_addon).with('myapp', 'heroku-postgresql', {switch => 'postgres://foo:yeah@awesome.com:234/bestdb'})
+          @addons.heroku.should_receive(:install_addon).with('example', 'heroku-postgresql', {switch => 'postgres://foo:yeah@awesome.com:234/bestdb'})
           @addons.add
         end
       end
@@ -226,7 +226,7 @@ STDOUT
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/releases/current}
+            :path => %r{^/apps/example/releases/current}
           },
           {
             :body   => Heroku::API::OkJson.encode({ 'name' => 'v99' }),
@@ -246,34 +246,34 @@ STDOUT
 
       it "adds an addon" do
         @addons.stub!(:args).and_return(%w(my_addon))
-        @addons.heroku.should_receive(:install_addon).with('myapp', 'my_addon', {})
+        @addons.heroku.should_receive(:install_addon).with('example', 'my_addon', {})
         @addons.add
       end
 
       it "adds an addon with a price" do
-        stub_core.install_addon("myapp", "my_addon", {}).returns({ "price" => "free" })
+        stub_core.install_addon("example", "my_addon", {}).returns({ "price" => "free" })
         stderr, stdout = execute("addons:add my_addon")
         stderr.should == ""
         stdout.should =~ /\(free\)/
       end
 
       it "adds an addon with a price and message" do
-        stub_core.install_addon("myapp", "my_addon", {}).returns({ "price" => "free", "message" => "foo" })
+        stub_core.install_addon("example", "my_addon", {}).returns({ "price" => "free", "message" => "foo" })
         stderr, stdout = execute("addons:add my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Adding my_addon on myapp... done, v99 (free)
+Adding my_addon on example... done, v99 (free)
 foo
 Use `heroku addons:docs my_addon` to view documentation.
 OUTPUT
       end
 
       it "adds an addon with a price and multiline message" do
-        stub_core.install_addon("myapp", "my_addon", {}).returns({ "price" => "$200/mo", "message" => "foo\nbar" })
+        stub_core.install_addon("example", "my_addon", {}).returns({ "price" => "$200/mo", "message" => "foo\nbar" })
         stderr, stdout = execute("addons:add my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Adding my_addon on myapp... done, v99 ($200/mo)
+Adding my_addon on example... done, v99 ($200/mo)
 foo
 bar
 Use `heroku addons:docs my_addon` to view documentation.
@@ -293,7 +293,7 @@ OUTPUT
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/releases/current}
+            :path => %r{^/apps/example/releases/current}
           },
           {
             :body   => Heroku::API::OkJson.encode({ 'name' => 'v99' }),
@@ -312,32 +312,32 @@ OUTPUT
 
       it "upgrades an addon" do
         @addons.stub!(:args).and_return(%w(my_addon))
-        @addons.heroku.should_receive(:upgrade_addon).with('myapp', 'my_addon', {})
+        @addons.heroku.should_receive(:upgrade_addon).with('example', 'my_addon', {})
         @addons.upgrade
       end
 
       it "upgrade an addon with config vars" do
         @addons.stub!(:args).and_return(%w(my_addon --foo=baz))
-        @addons.heroku.should_receive(:upgrade_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
+        @addons.heroku.should_receive(:upgrade_addon).with('example', 'my_addon', { 'foo' => 'baz' })
         @addons.upgrade
       end
 
       it "adds an addon with a price" do
-        stub_core.upgrade_addon("myapp", "my_addon", {}).returns({ "price" => "free" })
+        stub_core.upgrade_addon("example", "my_addon", {}).returns({ "price" => "free" })
         stderr, stdout = execute("addons:upgrade my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Upgrading to my_addon on myapp... done, v99 (free)
+Upgrading to my_addon on example... done, v99 (free)
 Use `heroku addons:docs my_addon` to view documentation.
 OUTPUT
       end
 
       it "adds an addon with a price and message" do
-        stub_core.upgrade_addon("myapp", "my_addon", {}).returns({ "price" => "free", "message" => "Don't Panic" })
+        stub_core.upgrade_addon("example", "my_addon", {}).returns({ "price" => "free", "message" => "Don't Panic" })
         stderr, stdout = execute("addons:upgrade my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Upgrading to my_addon on myapp... done, v99 (free)
+Upgrading to my_addon on example... done, v99 (free)
 Don't Panic
 Use `heroku addons:docs my_addon` to view documentation.
 OUTPUT
@@ -351,7 +351,7 @@ OUTPUT
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/releases/current}
+            :path => %r{^/apps/example/releases/current}
           },
           {
             :body   => Heroku::API::OkJson.encode({ 'name' => 'v99' }),
@@ -370,32 +370,32 @@ OUTPUT
 
       it "downgrades an addon" do
         @addons.stub!(:args).and_return(%w(my_addon))
-        @addons.heroku.should_receive(:upgrade_addon).with('myapp', 'my_addon', {})
+        @addons.heroku.should_receive(:upgrade_addon).with('example', 'my_addon', {})
         @addons.downgrade
       end
 
       it "downgrade an addon with config vars" do
         @addons.stub!(:args).and_return(%w(my_addon --foo=baz))
-        @addons.heroku.should_receive(:upgrade_addon).with('myapp', 'my_addon', { 'foo' => 'baz' })
+        @addons.heroku.should_receive(:upgrade_addon).with('example', 'my_addon', { 'foo' => 'baz' })
         @addons.downgrade
       end
 
       it "downgrades an addon with a price" do
-        stub_core.upgrade_addon("myapp", "my_addon", {}).returns({ "price" => "free" })
+        stub_core.upgrade_addon("example", "my_addon", {}).returns({ "price" => "free" })
         stderr, stdout = execute("addons:downgrade my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Downgrading to my_addon on myapp... done, v99 (free)
+Downgrading to my_addon on example... done, v99 (free)
 Use `heroku addons:docs my_addon` to view documentation.
 OUTPUT
       end
 
       it "downgrades an addon with a price and message" do
-        stub_core.upgrade_addon("myapp", "my_addon", {}).returns({ "price" => "free", "message" => "Don't Panic" })
+        stub_core.upgrade_addon("example", "my_addon", {}).returns({ "price" => "free", "message" => "Don't Panic" })
         stderr, stdout = execute("addons:downgrade my_addon")
         stderr.should == ""
         stdout.should == <<-OUTPUT
-Downgrading to my_addon on myapp... done, v99 (free)
+Downgrading to my_addon on example... done, v99 (free)
 Don't Panic
 Use `heroku addons:docs my_addon` to view documentation.
 OUTPUT
@@ -423,14 +423,14 @@ OUTPUT
     it "removes addons after prompting for confirmation" do
       @addons.stub!(:args).and_return(%w( addon1 ))
       @addons.should_receive(:confirm_command).once.and_return(true)
-      @addons.heroku.should_receive(:uninstall_addon).with('myapp', 'addon1', :confirm => "myapp")
+      @addons.heroku.should_receive(:uninstall_addon).with('example', 'addon1', :confirm => "example")
       @addons.remove
     end
 
     it "removes addons with confirm option" do
-      Heroku::Command.stub!(:current_options).and_return(:confirm => "myapp")
+      Heroku::Command.stub!(:current_options).and_return(:confirm => "example")
       @addons.stub!(:args).and_return(%w( addon1 ))
-      @addons.heroku.should_receive(:uninstall_addon).with('myapp', 'addon1', :confirm => "myapp")
+      @addons.heroku.should_receive(:uninstall_addon).with('example', 'addon1', :confirm => "example")
       @addons.remove
     end
 
@@ -438,11 +438,11 @@ OUTPUT
 
       before(:each) do
         stub_core
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "displays usage when no argument is specified" do
@@ -519,11 +519,11 @@ STDOUT
 
       before(:each) do
         stub_core
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "displays usage when no argument is specified" do
@@ -536,13 +536,13 @@ STDERR
       end
 
       it "opens the addon if only one matches" do
-        api.post_addon('myapp', 'redistogo:nano')
+        api.post_addon('example', 'redistogo:nano')
         require("launchy")
-        Launchy.should_receive(:open).with("https://api.#{@addons.heroku.host}/myapps/myapp/addons/redistogo:nano").and_return(Thread.new {})
+        Launchy.should_receive(:open).with("https://api.#{@addons.heroku.host}/apps/example/addons/redistogo:nano").and_return(Thread.new {})
         stderr, stdout = execute('addons:open redistogo:nano')
         stderr.should == ''
         stdout.should == <<-STDOUT
-Opening redistogo:nano for myapp... done
+Opening redistogo:nano for example... done
 STDOUT
       end
 
@@ -551,7 +551,7 @@ STDOUT
           {
             :expects => 200,
             :method => :get,
-            :path => %r{^/apps/myapp/addons$}
+            :path => %r{^/apps/example/addons$}
           },
           {
             :body   => Heroku::API::OkJson.encode([

--- a/spec/heroku/command/apps_spec.rb
+++ b/spec/heroku/command/apps_spec.rb
@@ -11,34 +11,34 @@ module Heroku::Command
     context("info") do
 
       before(:each) do
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "displays impicit app info" do
         stderr, stdout = execute("apps:info")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp
-Git URL:       git@heroku.com:myapp.git
+=== example
+Git URL:       git@heroku.com:example.git
 Owner Email:   email@example.com
 Stack:         cedar
-Web URL:       http://myapp.herokuapp.com/
+Web URL:       http://example.herokuapp.com/
 STDOUT
       end
 
       it "gets explicit app from --app" do
-        stderr, stdout = execute("apps:info --app myapp")
+        stderr, stdout = execute("apps:info --app example")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp
-Git URL:       git@heroku.com:myapp.git
+=== example
+Git URL:       git@heroku.com:example.git
 Owner Email:   email@example.com
 Stack:         cedar
-Web URL:       http://myapp.herokuapp.com/
+Web URL:       http://example.herokuapp.com/
 STDOUT
       end
 
@@ -49,16 +49,16 @@ STDOUT
 create_status=complete
 created_at=\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2} [+-]\\d{4}
 dynos=0
-git_url=git@heroku.com:myapp.git
+git_url=git@heroku.com:example.git
 id=\\d{1,5}
-name=myapp
+name=example
 owner_email=email@example.com
 repo_migrate_status=complete
 repo_size=
 requested_stack=
 slug_size=
 stack=cedar
-web_url=http://myapp.herokuapp.com/
+web_url=http://example.herokuapp.com/
 workers=0
 STDOUT
       end
@@ -84,40 +84,40 @@ STDOUT
 
       it "with a name" do
         with_blank_git_repository do
-          stderr, stdout = execute("apps:create myapp")
+          stderr, stdout = execute("apps:create example")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 Git remote heroku added
 STDOUT
         end
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "with -a name" do
         with_blank_git_repository do
-          stderr, stdout = execute("apps:create -a myapp")
+          stderr, stdout = execute("apps:create -a example")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 Git remote heroku added
 STDOUT
         end
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "with --no-remote" do
         with_blank_git_repository do
-          stderr, stdout = execute("apps:create myapp --no-remote")
+          stderr, stdout = execute("apps:create example --no-remote")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 STDOUT
         end
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "with addons" do
@@ -167,20 +167,20 @@ STDOUT
     context("index") do
 
       before(:each) do
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "succeeds" do
-        stub_core.list.returns([["myapp", "user"]])
+        stub_core.list.returns([["example", "user"]])
         stderr, stdout = execute("apps")
         stderr.should == ""
         stdout.should == <<-STDOUT
 === My Apps
-myapp
+example
 
 STDOUT
       end
@@ -192,20 +192,20 @@ STDOUT
       context("success") do
 
         before(:each) do
-          api.post_app("name" => "myapp", "stack" => "cedar")
+          api.post_app("name" => "example", "stack" => "cedar")
         end
 
         after(:each) do
-          api.delete_app("myapp2")
+          api.delete_app("example2")
         end
 
         it "renames app" do
           with_blank_git_repository do
-            stderr, stdout = execute("apps:rename myapp2")
+            stderr, stdout = execute("apps:rename example2")
             stderr.should == ""
             stdout.should == <<-STDOUT
-Renaming myapp to myapp2... done
-http://myapp2.herokuapp.com/ | git@heroku.com:myapp2.git
+Renaming example to example2... done
+http://example2.herokuapp.com/ | git@heroku.com:example2.git
 Don't forget to update your Git remotes on any local checkouts.
 STDOUT
           end
@@ -227,32 +227,32 @@ STDERR
     context("destroy") do
 
       before(:each) do
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       it "succeeds with app explicitly specified with --app and user confirmation" do
-        stderr, stdout = execute("apps:destroy --confirm myapp")
+        stderr, stdout = execute("apps:destroy --confirm example")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Destroying myapp (including all add-ons)... done
+Destroying example (including all add-ons)... done
 STDOUT
       end
 
       context("fails") do
 
         after(:each) do
-          api.delete_app("myapp")
+          api.delete_app("example")
         end
 
         it "fails with explicit app but no confirmation" do
-          stderr, stdout = execute("apps:destroy myapp")
+          stderr, stdout = execute("apps:destroy example")
           stderr.should == <<-STDERR
- !    Confirmation did not match myapp. Aborted.
+ !    Confirmation did not match example. Aborted.
 STDERR
           stdout.should == "
  !    WARNING: Potentially Destructive Action
- !    This command will destroy myapp (including all add-ons).
- !    To proceed, type \"myapp\" or re-run this command with --confirm myapp
+ !    This command will destroy example (including all add-ons).
+ !    To proceed, type \"example\" or re-run this command with --confirm example
 
 > "
 
@@ -275,73 +275,73 @@ STDERR
 
       it "creates adding heroku to git remote" do
         with_blank_git_repository do
-          stderr, stdout = execute("apps:create myapp")
+          stderr, stdout = execute("apps:create example")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 Git remote heroku added
 STDOUT
           `git remote`.strip.should match(/^heroku$/)
-          api.delete_app("myapp")
+          api.delete_app("example")
         end
       end
 
       it "creates adding a custom git remote" do
         with_blank_git_repository do
-          stderr, stdout = execute("apps:create myapp --remote myremote")
+          stderr, stdout = execute("apps:create example --remote myremote")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 Git remote myremote added
 STDOUT
           `git remote`.strip.should match(/^myremote$/)
-          api.delete_app("myapp")
+          api.delete_app("example")
         end
       end
 
       it "doesn't add a git remote if it already exists" do
         with_blank_git_repository do
           `git remote add heroku /tmp/git_spec_#{Process.pid}`
-          stderr, stdout = execute("apps:create myapp")
+          stderr, stdout = execute("apps:create example")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Creating myapp... done, stack is bamboo-mri-1.9.2
-http://myapp.herokuapp.com/ | git@heroku.com:myapp.git
+Creating example... done, stack is bamboo-mri-1.9.2
+http://example.herokuapp.com/ | git@heroku.com:example.git
 STDOUT
-          api.delete_app("myapp")
+          api.delete_app("example")
         end
       end
 
       it "renames updating the corresponding heroku git remote" do
         with_blank_git_repository do
           `git remote add github     git@github.com:test/test.git`
-          `git remote add production git@heroku.com:myapp.git`
-          `git remote add staging    git@heroku.com:myapp-staging.git`
+          `git remote add production git@heroku.com:example.git`
+          `git remote add staging    git@heroku.com:example-staging.git`
 
-          api.post_app("name" => "myapp", "stack" => "cedar")
-          stderr, stdout = execute("apps:rename myapp2")
-          api.delete_app("myapp2")
+          api.post_app("name" => "example", "stack" => "cedar")
+          stderr, stdout = execute("apps:rename example2")
+          api.delete_app("example2")
 
           remotes = `git remote -v`
           remotes.should == <<-REMOTES
 github\tgit@github.com:test/test.git (fetch)
 github\tgit@github.com:test/test.git (push)
-production\tgit@heroku.com:myapp2.git (fetch)
-production\tgit@heroku.com:myapp2.git (push)
-staging\tgit@heroku.com:myapp-staging.git (fetch)
-staging\tgit@heroku.com:myapp-staging.git (push)
+production\tgit@heroku.com:example2.git (fetch)
+production\tgit@heroku.com:example2.git (push)
+staging\tgit@heroku.com:example-staging.git (fetch)
+staging\tgit@heroku.com:example-staging.git (push)
 REMOTES
         end
       end
 
       it "destroys removing any remotes pointing to the app" do
         with_blank_git_repository do
-          `git remote add heroku git@heroku.com:myapp.git`
+          `git remote add heroku git@heroku.com:example.git`
 
-          api.post_app("name" => "myapp", "stack" => "cedar")
-          stderr, stdout = execute("apps:destroy --confirm myapp")
+          api.post_app("name" => "example", "stack" => "cedar")
+          stderr, stdout = execute("apps:destroy --confirm example")
 
           `git remote`.strip.should_not include('heroku')
         end

--- a/spec/heroku/command/base_spec.rb
+++ b/spec/heroku/command/base_spec.rb
@@ -11,40 +11,40 @@ module Heroku::Command
 
     describe "confirming" do
       it "confirms the app via --confirm" do
-        Heroku::Command.stub(:current_options).and_return(:confirm => "myapp")
-        @base.stub(:app).and_return("myapp")
+        Heroku::Command.stub(:current_options).and_return(:confirm => "example")
+        @base.stub(:app).and_return("example")
         @base.confirm_command.should be_true
       end
 
       it "does not confirms the app via --confirm on a mismatch" do
         Heroku::Command.stub(:current_options).and_return(:confirm => "badapp")
-        @base.stub(:app).and_return("myapp")
+        @base.stub(:app).and_return("example")
         lambda { @base.confirm_command}.should raise_error CommandFailed
       end
 
       it "confirms the app interactively via ask" do
-        @base.stub(:app).and_return("myapp")
-        @base.stub(:ask).and_return("myapp")
+        @base.stub(:app).and_return("example")
+        @base.stub(:ask).and_return("example")
         Heroku::Command.stub(:current_options).and_return({})
         @base.confirm_command.should be_true
       end
 
       it "fails if the interactive confirm doesn't match" do
-        @base.stub(:app).and_return("myapp")
+        @base.stub(:app).and_return("example")
         @base.stub(:ask).and_return("badresponse")
         Heroku::Command.stub(:current_options).and_return({})
         capture_stderr do
           lambda { @base.confirm_command }.should raise_error(SystemExit)
         end.should == <<-STDERR
- !    Confirmation did not match myapp. Aborted.
+ !    Confirmation did not match example. Aborted.
 STDERR
       end
     end
 
     context "detecting the app" do
       it "attempts to find the app via the --app option" do
-        @base.stub!(:options).and_return(:app => "myapp")
-        @base.app.should == "myapp"
+        @base.stub!(:options).and_return(:app => "example")
+        @base.app.should == "example"
       end
 
       it "attempts to find the app via the --confirm option" do
@@ -62,8 +62,8 @@ STDERR
 
       it "overrides HEROKU_APP when explicitly specified" do
         ENV['HEROKU_APP'] = "myenvapp"
-        @base.stub!(:options).and_return(:app => "myapp")
-        @base.app.should == "myapp"
+        @base.stub!(:options).and_return(:app => "example")
+        @base.app.should == "example"
         ENV.delete('HEROKU_APP')
       end
 
@@ -71,10 +71,10 @@ STDERR
         Dir.stub(:chdir)
         File.should_receive(:exists?).with(".git").and_return(true)
         @base.should_receive(:git).with('remote -v').and_return(<<-REMOTES)
-staging\tgit@heroku.com:myapp-staging.git (fetch)
-staging\tgit@heroku.com:myapp-staging.git (push)
-production\tgit@heroku.com:myapp.git (fetch)
-production\tgit@heroku.com:myapp.git (push)
+staging\tgit@heroku.com:example-staging.git (fetch)
+staging\tgit@heroku.com:example-staging.git (push)
+production\tgit@heroku.com:example.git (fetch)
+production\tgit@heroku.com:example.git (push)
 other\tgit@other.com:other.git (fetch)
 other\tgit@other.com:other.git (push)
         REMOTES
@@ -84,23 +84,23 @@ other\tgit@other.com:other.git (push)
         @base.stub(:heroku).and_return(@heroku)
 
         # need a better way to test internal functionality
-        @base.send(:git_remotes, '/home/dev/myapp').should == { 'staging' => 'myapp-staging', 'production' => 'myapp' }
+        @base.send(:git_remotes, '/home/dev/example').should == { 'staging' => 'example-staging', 'production' => 'example' }
       end
 
       it "gets the app from remotes when there's only one app" do
-        @base.stub!(:git_remotes).and_return({ 'heroku' => 'myapp' })
+        @base.stub!(:git_remotes).and_return({ 'heroku' => 'example' })
         @base.stub!(:git).with("config heroku.remote").and_return("")
-        @base.app.should == 'myapp'
+        @base.app.should == 'example'
       end
 
       it "accepts a --remote argument to choose the app from the remote name" do
-        @base.stub!(:git_remotes).and_return({ 'staging' => 'myapp-staging', 'production' => 'myapp' })
+        @base.stub!(:git_remotes).and_return({ 'staging' => 'example-staging', 'production' => 'example' })
         @base.stub!(:options).and_return(:remote => "staging")
-        @base.app.should == 'myapp-staging'
+        @base.app.should == 'example-staging'
       end
 
       it "raises when cannot determine which app is it" do
-        @base.stub!(:git_remotes).and_return({ 'staging' => 'myapp-staging', 'production' => 'myapp' })
+        @base.stub!(:git_remotes).and_return({ 'staging' => 'example-staging', 'production' => 'example' })
         lambda { @base.app }.should raise_error(Heroku::Command::CommandFailed)
       end
     end

--- a/spec/heroku/command/certs_spec.rb
+++ b/spec/heroku/command/certs_spec.rb
@@ -41,7 +41,7 @@ SSL certificate is self signed.
 
     describe "certs" do
       it "shows a list of certs" do
-        stub_core.ssl_endpoint_list("myapp").returns([endpoint, endpoint2])
+        stub_core.ssl_endpoint_list("example").returns([endpoint, endpoint2])
         stderr, stdout = execute("certs")
         stdout.should == <<-STDOUT
 Endpoint                  Common Name(s)  Expires               Trusted
@@ -52,10 +52,10 @@ STDOUT
       end
 
       it "warns about no SSL Endpoints if the app has no certs" do
-        stub_core.ssl_endpoint_list("myapp").returns([])
+        stub_core.ssl_endpoint_list("example").returns([])
         stderr, stdout = execute("certs")
         stdout.should == <<-STDOUT
-myapp has no SSL Endpoints.
+example has no SSL Endpoints.
 Use `heroku certs:add PEM KEY` to add one.
         STDOUT
       end
@@ -65,12 +65,12 @@ Use `heroku certs:add PEM KEY` to add one.
       it "adds an endpoint" do
         File.should_receive(:read).with("pem_file").and_return("pem content")
         File.should_receive(:read).with("key_file").and_return("key content")
-        stub_core.ssl_endpoint_add('myapp', 'pem content', 'key content').returns(endpoint)
+        stub_core.ssl_endpoint_add('example', 'pem content', 'key content').returns(endpoint)
 
         stderr, stdout = execute("certs:add pem_file key_file")
         stdout.should == <<-STDOUT
-Adding SSL Endpoint to myapp... done
-myapp now served by tokyo-1050.herokussl.com
+Adding SSL Endpoint to example... done
+example now served by tokyo-1050.herokussl.com
 Certificate details:
 #{certificate_details}
         STDOUT
@@ -83,43 +83,43 @@ Certificate details:
 
     describe "certs:info" do
       it "shows certificate details" do
-        stub_core.ssl_endpoint_list("myapp").returns([endpoint])
-        stub_core.ssl_endpoint_info('myapp', 'tokyo-1050.herokussl.com').returns(endpoint)
+        stub_core.ssl_endpoint_list("example").returns([endpoint])
+        stub_core.ssl_endpoint_info('example', 'tokyo-1050.herokussl.com').returns(endpoint)
 
         stderr, stdout = execute("certs:info")
         stdout.should == <<-STDOUT
-Fetching SSL Endpoint tokyo-1050.herokussl.com info for myapp... done
+Fetching SSL Endpoint tokyo-1050.herokussl.com info for example... done
 Certificate details:
 #{certificate_details}
         STDOUT
       end
 
       it "shows an error if an app has no endpoints" do
-        stub_core.ssl_endpoint_list("myapp").returns([])
+        stub_core.ssl_endpoint_list("example").returns([])
 
         stderr, stdout = execute("certs:info")
         stderr.should == <<-STDERR
- !    myapp has no SSL Endpoints.
+ !    example has no SSL Endpoints.
         STDERR
       end
     end
 
     describe "certs:remove" do
       it "removes an endpoint" do
-        stub_core.ssl_endpoint_list("myapp").returns([endpoint])
-        stub_core.ssl_endpoint_remove('myapp', 'tokyo-1050.herokussl.com').returns(endpoint)
+        stub_core.ssl_endpoint_list("example").returns([endpoint])
+        stub_core.ssl_endpoint_remove('example', 'tokyo-1050.herokussl.com').returns(endpoint)
 
         stderr, stdout = execute("certs:remove")
-        stdout.should include "Removing SSL Endpoint tokyo-1050.herokussl.com from myapp..."
+        stdout.should include "Removing SSL Endpoint tokyo-1050.herokussl.com from example..."
         stdout.should include "NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing."
       end
 
       it "shows an error if an app has no endpoints" do
-        stub_core.ssl_endpoint_list("myapp").returns([])
+        stub_core.ssl_endpoint_list("example").returns([])
 
         stderr, stdout = execute("certs:remove")
         stderr.should == <<-STDERR
- !    myapp has no SSL Endpoints.
+ !    example has no SSL Endpoints.
         STDERR
       end
     end
@@ -131,46 +131,46 @@ Certificate details:
       end
 
       it "updates an endpoint" do
-        stub_core.ssl_endpoint_list("myapp").returns([endpoint])
-        stub_core.ssl_endpoint_update('myapp', 'tokyo-1050.herokussl.com', 'pem content', 'key content').returns(endpoint)
+        stub_core.ssl_endpoint_list("example").returns([endpoint])
+        stub_core.ssl_endpoint_update('example', 'tokyo-1050.herokussl.com', 'pem content', 'key content').returns(endpoint)
 
         stderr, stdout = execute("certs:update pem_file key_file")
         stdout.should == <<-STDOUT
-Updating SSL Endpoint tokyo-1050.herokussl.com for myapp... done
+Updating SSL Endpoint tokyo-1050.herokussl.com for example... done
 Updated certificate details:
 #{certificate_details}
         STDOUT
       end
 
       it "shows an error if an app has no endpoints" do
-        stub_core.ssl_endpoint_list("myapp").returns([])
+        stub_core.ssl_endpoint_list("example").returns([])
 
         stderr, stdout = execute("certs:update pem_file key_file")
         stderr.should == <<-STDERR
- !    myapp has no SSL Endpoints.
+ !    example has no SSL Endpoints.
         STDERR
       end
     end
 
     describe "certs:rollback" do
       it "performs a rollback on an endpoint" do
-        stub_core.ssl_endpoint_list("myapp").returns([endpoint])
-        stub_core.ssl_endpoint_rollback('myapp', 'tokyo-1050.herokussl.com').returns(endpoint)
+        stub_core.ssl_endpoint_list("example").returns([endpoint])
+        stub_core.ssl_endpoint_rollback('example', 'tokyo-1050.herokussl.com').returns(endpoint)
 
         stderr, stdout = execute("certs:rollback")
         stdout.should == <<-STDOUT
-Rolling back SSL Endpoint tokyo-1050.herokussl.com for myapp... done
+Rolling back SSL Endpoint tokyo-1050.herokussl.com for example... done
 New active certificate details:
 #{certificate_details}
         STDOUT
       end
 
       it "shows an error if an app has no endpoints" do
-        stub_core.ssl_endpoint_list("myapp").returns([])
+        stub_core.ssl_endpoint_list("example").returns([])
 
         stderr, stdout = execute("certs:rollback")
         stderr.should == <<-STDERR
- !    myapp has no SSL Endpoints.
+ !    example has no SSL Endpoints.
         STDERR
       end
     end

--- a/spec/heroku/command/config_spec.rb
+++ b/spec/heroku/command/config_spec.rb
@@ -5,58 +5,58 @@ module Heroku::Command
   describe Config do
     before(:each) do
       stub_core
-      api.post_app("name" => "myapp", "stack" => "cedar")
+      api.post_app("name" => "example", "stack" => "cedar")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "shows all configs" do
-      api.put_config_vars("myapp", { 'FOO_BAR' => 'one', 'BAZ_QUX' => 'two' })
+      api.put_config_vars("example", { 'FOO_BAR' => 'one', 'BAZ_QUX' => 'two' })
       stderr, stdout = execute("config")
       stderr.should == ""
       stdout.should == <<-STDOUT
-=== myapp Config Vars
+=== example Config Vars
 BAZ_QUX: two
 FOO_BAR: one
 STDOUT
     end
 
     it "does not trim long values" do
-      api.put_config_vars("myapp", { 'LONG' => 'A' * 60 })
+      api.put_config_vars("example", { 'LONG' => 'A' * 60 })
       stderr, stdout = execute("config")
       stderr.should == ""
       stdout.should == <<-STDOUT
-=== myapp Config Vars
+=== example Config Vars
 LONG: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 STDOUT
     end
 
     it "handles when value is nil" do
-      api.put_config_vars("myapp", { 'FOO_BAR' => 'one', 'BAZ_QUX' => nil })
+      api.put_config_vars("example", { 'FOO_BAR' => 'one', 'BAZ_QUX' => nil })
       stderr, stdout = execute("config")
       stderr.should == ""
       stdout.should == <<-STDOUT
-=== myapp Config Vars
+=== example Config Vars
 BAZ_QUX: 
 FOO_BAR: one
 STDOUT
     end
 
     it "handles when value is a boolean" do
-      api.put_config_vars("myapp", { 'FOO_BAR' => 'one', 'BAZ_QUX' => true })
+      api.put_config_vars("example", { 'FOO_BAR' => 'one', 'BAZ_QUX' => true })
       stderr, stdout = execute("config")
       stderr.should == ""
       stdout.should == <<-STDOUT
-=== myapp Config Vars
+=== example Config Vars
 BAZ_QUX: true
 FOO_BAR: one
 STDOUT
     end
 
     it "shows configs in a shell compatible format" do
-      api.put_config_vars("myapp", { 'A' => 'one', 'B' => 'two three' })
+      api.put_config_vars("example", { 'A' => 'one', 'B' => 'two three' })
       stderr, stdout = execute("config --shell")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -66,7 +66,7 @@ STDOUT
     end
 
     it "shows a single config for get" do
-      api.put_config_vars("myapp", { 'LONG' => 'A' * 60 })
+      api.put_config_vars("example", { 'LONG' => 'A' * 60 })
       stderr, stdout = execute("config:get LONG")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -80,7 +80,7 @@ STDOUT
         stderr, stdout = execute("config:set A=1 B=2")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Setting config vars and restarting myapp... done, v1
+Setting config vars and restarting example... done, v1
 A: 1
 B: 2
       STDOUT
@@ -90,7 +90,7 @@ B: 2
         stderr, stdout = execute("config:set A=b=c")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Setting config vars and restarting myapp... done, v1
+Setting config vars and restarting example... done, v1
 A: b=c
 STDOUT
       end
@@ -99,7 +99,7 @@ STDOUT
         stderr, stdout = execute("config:set a=b")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Setting config vars and restarting myapp... done, v1
+Setting config vars and restarting example... done, v1
 a: b
 STDOUT
       end
@@ -123,7 +123,7 @@ STDERR
           stderr, stdout = execute("config:unset A")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Unsetting A and restarting myapp... done, v1
+Unsetting A and restarting example... done, v1
 STDOUT
         end
       end
@@ -134,8 +134,8 @@ STDOUT
           stderr, stdout = execute("config:unset A B")
           stderr.should == ""
           stdout.should == <<-STDOUT
-Unsetting A and restarting myapp... done, v1
-Unsetting B and restarting myapp... done, v2
+Unsetting A and restarting example... done, v1
+Unsetting B and restarting example... done, v2
 STDOUT
         end
       end

--- a/spec/heroku/command/db_spec.rb
+++ b/spec/heroku/command/db_spec.rb
@@ -55,7 +55,7 @@ module Heroku::Command
 
     it "handles both a url and a --confirm on the command line" do
       pending("requires taps") unless taps_available?
-      Heroku::Command.stub!(:current_options).and_return(:confirm => "myapp")
+      Heroku::Command.stub!(:current_options).and_return(:confirm => "example")
       @db.stub!(:args).and_return(["mysql://user:pass@host/db"])
       opts = { :database_url => 'mysql://user:pass@host/db', :default_chunksize => 1000, :indexes_first => true }
       @db.should_receive(:taps_client).with(:pull, opts)
@@ -64,7 +64,7 @@ module Heroku::Command
 
     it "handles no url and --confirm on the command line" do
       pending("requires taps") unless taps_available?
-      Heroku::Command.stub!(:current_options).and_return(:confirm => "myapp")
+      Heroku::Command.stub!(:current_options).and_return(:confirm => "example")
       opts = { :database_url => 'mysql://user:pass@host/db', :default_chunksize => 1000, :indexes_first => true }
       @db.should_receive(:parse_database_yml).and_return("mysql://user:pass@host/db")
       @db.should_receive(:taps_client).with(:pull, opts)
@@ -74,7 +74,7 @@ module Heroku::Command
     it "works with a file-based url" do
       pending("requires taps") unless taps_available?
       url = "sqlite://tmp/foo.db"
-      Heroku::Command.stub(:current_options).and_return(:confirm => "myapp")
+      Heroku::Command.stub(:current_options).and_return(:confirm => "example")
       @db.stub(:args).and_return([url])
       @db.should_receive(:taps_client).with(:pull, hash_including(:database_url => url))
       @db.pull

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -5,12 +5,12 @@ module Heroku::Command
   describe Domains do
 
     before(:all) do
-      api.post_app("name" => "myapp", "stack" => "cedar")
-      api.post_addon("myapp", "custom_domains:basic")
+      api.post_app("name" => "example", "stack" => "cedar")
+      api.post_addon("example", "custom_domains:basic")
     end
 
     after(:all) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     before(:each) do
@@ -23,20 +23,20 @@ module Heroku::Command
         stderr, stdout = execute("domains")
         stderr.should == ""
         stdout.should == <<-STDOUT
-myapp has no domain names.
+example has no domain names.
 STDOUT
       end
 
       it "lists domains when some exist" do
-        api.post_domain("myapp", "example.com")
+        api.post_domain("example", "example.com")
         stderr, stdout = execute("domains")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp Domain Names
+=== example Domain Names
 example.com
 
 STDOUT
-        api.delete_domain("myapp", "example.com")
+        api.delete_domain("example", "example.com")
       end
 
     end
@@ -45,9 +45,9 @@ STDOUT
       stderr, stdout = execute("domains:add example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Adding example.com to myapp... done
+Adding example.com to example... done
 STDOUT
-      api.delete_domain("myapp", "example.com")
+      api.delete_domain("example", "example.com")
     end
 
     it "shows usage if no domain specified for add" do
@@ -59,11 +59,11 @@ STDOUT
     end
 
     it "removes domain names" do
-      api.post_domain("myapp", "example.com")
+      api.post_domain("example", "example.com")
       stderr, stdout = execute("domains:remove example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Removing example.com from myapp... done
+Removing example.com from example... done
 STDOUT
     end
 
@@ -76,11 +76,11 @@ STDOUT
     end
 
     it "removes all domain names" do
-      stub_core.remove_domains("myapp")
+      stub_core.remove_domains("example")
       stderr, stdout = execute("domains:clear")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Removing all domain names from myapp... done
+Removing all domain names from example... done
 STDOUT
     end
   end

--- a/spec/heroku/command/drains_spec.rb
+++ b/spec/heroku/command/drains_spec.rb
@@ -5,7 +5,7 @@ describe Heroku::Command::Drains do
 
   describe "drains" do
     it "can list drains" do
-      stub_core.list_drains("myapp").returns("drains")
+      stub_core.list_drains("example").returns("drains")
       stderr, stdout = execute("drains")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -14,7 +14,7 @@ STDOUT
     end
 
     it "can add drains" do
-      stub_core.add_drain("myapp", "syslog://localhost/add").returns("added")
+      stub_core.add_drain("example", "syslog://localhost/add").returns("added")
       stderr, stdout = execute("drains:add syslog://localhost/add")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -23,7 +23,7 @@ STDOUT
     end
 
     it "can remove drains" do
-      stub_core.remove_drain("myapp", "syslog://localhost/remove").returns("removed")
+      stub_core.remove_drain("example", "syslog://localhost/remove").returns("removed")
       stderr, stdout = execute("drains:remove syslog://localhost/remove")
       stderr.should == ""
       stdout.should == <<-STDOUT

--- a/spec/heroku/command/git_spec.rb
+++ b/spec/heroku/command/git_spec.rb
@@ -11,80 +11,80 @@ module Heroku::Command
     context("clone") do
 
       before(:each) do
-        api.post_app("name" => "myapp", "stack" => "cedar")
+        api.post_app("name" => "example", "stack" => "cedar")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "clones and adds remote" do
         any_instance_of(Heroku::Command::Git) do |git|
-          mock(git).system("git clone -o heroku git@heroku.com:myapp.git") do
-            puts "Cloning into 'myapp'..."
+          mock(git).system("git clone -o heroku git@heroku.com:example.git") do
+            puts "Cloning into 'example'..."
           end
         end
-        stderr, stdout = execute("git:clone myapp")
+        stderr, stdout = execute("git:clone example")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Cloning from app 'myapp'...
-Cloning into 'myapp'...
+Cloning from app 'example'...
+Cloning into 'example'...
         STDOUT
       end
 
       it "clones into another dir" do
         any_instance_of(Heroku::Command::Git) do |git|
-          mock(git).system("git clone -o heroku git@heroku.com:myapp.git somedir") do
+          mock(git).system("git clone -o heroku git@heroku.com:example.git somedir") do
             puts "Cloning into 'somedir'..."
           end
         end
-        stderr, stdout = execute("git:clone myapp somedir")
+        stderr, stdout = execute("git:clone example somedir")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Cloning from app 'myapp'...
+Cloning from app 'example'...
 Cloning into 'somedir'...
         STDOUT
       end
 
       it "can specify app with -a" do
         any_instance_of(Heroku::Command::Git) do |git|
-          mock(git).system("git clone -o heroku git@heroku.com:myapp.git") do
-            puts "Cloning into 'myapp'..."
+          mock(git).system("git clone -o heroku git@heroku.com:example.git") do
+            puts "Cloning into 'example'..."
           end
         end
-        stderr, stdout = execute("git:clone -a myapp")
+        stderr, stdout = execute("git:clone -a example")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Cloning from app 'myapp'...
-Cloning into 'myapp'...
+Cloning from app 'example'...
+Cloning into 'example'...
         STDOUT
       end
 
       it "can specify app with -a and a dir" do
         any_instance_of(Heroku::Command::Git) do |git|
-          mock(git).system("git clone -o heroku git@heroku.com:myapp.git somedir") do
+          mock(git).system("git clone -o heroku git@heroku.com:example.git somedir") do
             puts "Cloning into 'somedir'..."
           end
         end
-        stderr, stdout = execute("git:clone -a myapp somedir")
+        stderr, stdout = execute("git:clone -a example somedir")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Cloning from app 'myapp'...
+Cloning from app 'example'...
 Cloning into 'somedir'...
         STDOUT
       end
 
       it "clones and sets -r remote" do
         any_instance_of(Heroku::Command::Git) do |git|
-          mock(git).system("git clone -o other git@heroku.com:myapp.git") do
-            puts "Cloning into 'myapp'..."
+          mock(git).system("git clone -o other git@heroku.com:example.git") do
+            puts "Cloning into 'example'..."
           end
         end
-        stderr, stdout = execute("git:clone myapp -r other")
+        stderr, stdout = execute("git:clone example -r other")
         stderr.should == ""
         stdout.should == <<-STDOUT
-Cloning from app 'myapp'...
-Cloning into 'myapp'...
+Cloning from app 'example'...
+Cloning into 'example'...
         STDOUT
       end
 
@@ -93,20 +93,20 @@ Cloning into 'myapp'...
     context("remote") do
 
       before(:each) do
-        api.post_app("name" => "myapp", "stack" => "cedar")
-        FileUtils.mkdir('myapp')
-        FileUtils.chdir('myapp') { `git init` }
+        api.post_app("name" => "example", "stack" => "cedar")
+        FileUtils.mkdir('example')
+        FileUtils.chdir('example') { `git init` }
       end
 
       after(:each) do
-        api.delete_app("myapp")
-        FileUtils.rm_rf('myapp')
+        api.delete_app("example")
+        FileUtils.rm_rf('example')
       end
 
       it "adds remote" do
         any_instance_of(Heroku::Command::Git) do |git|
           stub(git).git('remote').returns("origin")
-          stub(git).git('remote add heroku git@heroku.com:myapp.git')
+          stub(git).git('remote add heroku git@heroku.com:example.git')
         end
         stderr, stdout = execute("git:remote")
         stderr.should == ""
@@ -118,7 +118,7 @@ Git remote heroku added
       it "adds -r remote" do
         any_instance_of(Heroku::Command::Git) do |git|
           stub(git).git('remote').returns("origin")
-          stub(git).git('remote add other git@heroku.com:myapp.git')
+          stub(git).git('remote add other git@heroku.com:example.git')
         end
         stderr, stdout = execute("git:remote -r other")
         stderr.should == ""

--- a/spec/heroku/command/labs_spec.rb
+++ b/spec/heroku/command/labs_spec.rb
@@ -7,11 +7,11 @@ module Heroku::Command
 
     before(:each) do
       stub_core
-      api.post_app("name" => "myapp", "stack" => "cedar")
+      api.post_app("name" => "example", "stack" => "cedar")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "lists available features" do
@@ -21,21 +21,21 @@ module Heroku::Command
 === User Features (email@example.com)
 [ ] sumo-rankings  Heroku Sumo ranks and visualizes the scale of your app, and suggests the optimum combination of dynos and add-ons to take it to the next level.
 
-=== App Features (myapp)
+=== App Features (example)
 [+] sigterm-all       When stopping a dyno, send SIGTERM to all processes rather than only to the root process.
 [ ] user_env_compile  Add user config vars to the environment during slug compilation
 STDOUT
     end
 
     it "lists enabled features" do
-      stub_core.list_features("myapp").returns([])
+      stub_core.list_features("example").returns([])
       stderr, stdout = execute("labs")
       stderr.should == ""
       stdout.should == <<-STDOUT
 === User Features (email@example.com)
 [ ] sumo-rankings  Heroku Sumo ranks and visualizes the scale of your app, and suggests the optimum combination of dynos and add-ons to take it to the next level.
 
-=== App Features (myapp)
+=== App Features (example)
 [+] sigterm-all       When stopping a dyno, send SIGTERM to all processes rather than only to the root process.
 [ ] user_env_compile  Add user config vars to the environment during slug compilation
 STDOUT
@@ -64,7 +64,7 @@ STDERR
       stderr, stdout = execute("labs:enable user_env_compile")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Enabling user_env_compile for myapp... done
+Enabling user_env_compile for example... done
 WARNING: This feature is experimental and may change or be removed without notice.
 For more information see: http://devcenter.heroku.com/articles/labs-user-env-compile
 STDOUT
@@ -80,11 +80,11 @@ STDERR
     end
 
     it "disables a feature" do
-      api.post_feature('user_env_compile', 'myapp')
+      api.post_feature('user_env_compile', 'example')
       stderr, stdout = execute("labs:disable user_env_compile")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Disabling user_env_compile for myapp... done
+Disabling user_env_compile for example... done
 STDOUT
     end
 

--- a/spec/heroku/command/logs_spec.rb
+++ b/spec/heroku/command/logs_spec.rb
@@ -4,12 +4,12 @@ require "heroku/command/logs"
 describe Heroku::Command::Logs do
   describe "logs" do
     it "runs with no options" do
-      stub_core.read_logs("myapp", [])
+      stub_core.read_logs("example", [])
       execute "logs"
     end
 
     it "runs with options" do
-      stub_core.read_logs("myapp", [
+      stub_core.read_logs("example", [
         "tail=1",
         "num=2",
         "ps=ps.3",
@@ -20,7 +20,7 @@ describe Heroku::Command::Logs do
 
     describe "with log output" do
       before(:each) do
-        stub_core.read_logs("myapp", []).yields("2011-01-01T00:00:00+00:00 app[web.1]: test")
+        stub_core.read_logs("example", []).yields("2011-01-01T00:00:00+00:00 app[web.1]: test")
       end
 
       it "prettifies tty output" do

--- a/spec/heroku/command/maintenance_spec.rb
+++ b/spec/heroku/command/maintenance_spec.rb
@@ -6,11 +6,11 @@ module Heroku::Command
 
     before(:each) do
       stub_core
-      api.post_app("name" => "myapp", "stack" => "cedar")
+      api.post_app("name" => "example", "stack" => "cedar")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "displays off for maintenance mode of an app" do
@@ -22,7 +22,7 @@ STDOUT
     end
 
     it "displays on for maintenance mode of an app" do
-      api.post_app_maintenance('myapp', '1')
+      api.post_app_maintenance('example', '1')
 
       stderr, stdout = execute("maintenance")
       stderr.should == ""
@@ -35,7 +35,7 @@ STDOUT
       stderr, stdout = execute("maintenance:on")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Enabling maintenance mode for myapp... done
+Enabling maintenance mode for example... done
 STDOUT
     end
 
@@ -43,7 +43,7 @@ STDOUT
       stderr, stdout = execute("maintenance:off")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Disabling maintenance mode for myapp... done
+Disabling maintenance mode for example... done
 STDOUT
     end
 

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -6,8 +6,8 @@ module Heroku::Command
     before do
       stub_core
 
-      api.post_app "name" => "myapp"
-      api.put_config_vars "myapp", {
+      api.post_app "name" => "example"
+      api.put_config_vars "example", {
         "DATABASE_URL" => "postgres://database_url",
         "SHARED_DATABASE_URL" => "postgres://shared_database_url",
         "HEROKU_POSTGRESQL_IVORY_URL" => "postgres://database_url",
@@ -36,13 +36,13 @@ module Heroku::Command
     end
 
     after do
-      api.delete_app "myapp"
+      api.delete_app "example"
     end
 
     it "resets the app's database if user confirms" do
       stub_pg.reset
 
-      stderr, stdout = execute("pg:reset RONIN --confirm myapp")
+      stderr, stdout = execute("pg:reset RONIN --confirm example")
       stderr.should == ""
       stdout.should == <<-STDOUT
 Resetting HEROKU_POSTGRESQL_RONIN_URL... done
@@ -50,9 +50,9 @@ STDOUT
     end
 
     it "resets shared databases" do
-      Heroku::Client.any_instance.should_receive(:database_reset).with('myapp')
+      Heroku::Client.any_instance.should_receive(:database_reset).with('example')
 
-      stderr, stdout = execute("pg:reset SHARED_DATABASE --confirm myapp")
+      stderr, stdout = execute("pg:reset SHARED_DATABASE --confirm example")
       stderr.should == ''
       stdout.should == <<-STDOUT
 Resetting SHARED_DATABASE... done
@@ -64,12 +64,12 @@ STDOUT
 
       stderr, stdout = execute("pg:reset RONIN")
       stderr.should == <<-STDERR
- !    Confirmation did not match myapp. Aborted.
+ !    Confirmation did not match example. Aborted.
 STDERR
       stdout.should == "
  !    WARNING: Destructive Action
- !    This command will affect the app: myapp
- !    To proceed, type \"myapp\" or re-run this command with --confirm myapp
+ !    This command will affect the app: example
+ !    To proceed, type \"example\" or re-run this command with --confirm example
 
 > "
     end
@@ -161,12 +161,12 @@ STDOUT
 
     context "promotion" do
       it "promotes the specified database" do
-        stderr, stdout = execute("pg:promote RONIN --confirm myapp")
+        stderr, stdout = execute("pg:promote RONIN --confirm example")
         stderr.should == ""
         stdout.should == <<-STDOUT
 Promoting HEROKU_POSTGRESQL_RONIN_URL to DATABASE_URL... done
 STDOUT
-        api.get_config_vars("myapp").body["DATABASE_URL"].should == "postgres://ronin_database_url"
+        api.get_config_vars("example").body["DATABASE_URL"].should == "postgres://ronin_database_url"
       end
 
       it "fails if no database is specified" do
@@ -192,7 +192,7 @@ STDOUT
 
       it "does not update DATABASE_URL if it's not the main db" do
         stub_pg.rotate_credentials
-        api.put_config_vars "myapp", {
+        api.put_config_vars "example", {
           "DATABASE_URL" => "postgres://to_reset_credentials",
           "HEROKU_POSTGRESQL_RESETME_URL" => "postgres://something_else"
         }
@@ -222,7 +222,7 @@ STDOUT
             {"name"=>"Maintenance", "values"=>["not required"]}
           ]
         )
-        stderr, stdout = execute("pg:unfollow HEROKU_POSTGRESQL_FOLLOW_URL --confirm myapp")
+        stderr, stdout = execute("pg:unfollow HEROKU_POSTGRESQL_FOLLOW_URL --confirm example")
         stderr.should == ""
         stdout.should == <<-STDOUT
  !    HEROKU_POSTGRESQL_FOLLOW_URL will become writable and no longer

--- a/spec/heroku/command/pgbackups_spec.rb
+++ b/spec/heroku/command/pgbackups_spec.rb
@@ -7,9 +7,9 @@ module Heroku::Command
       @pgbackups = prepare_command(Pgbackups)
       @pgbackups.heroku.stub!(:info).and_return({})
 
-      api.post_app("name" => "myapp")
+      api.post_app("name" => "example")
       api.put_config_vars(
-        "myapp",
+        "example",
         {
           "DATABASE_URL"            => "postgres://database",
           "HEROKU_POSTGRESQL_IVORY" => "postgres://database",
@@ -30,7 +30,7 @@ module Heroku::Command
     }
 
     after do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "requests a pgbackups transfer list for the index command" do
@@ -132,7 +132,7 @@ STDOUT
       end
 
       it "aborts if no database addon is present" do
-        api.delete_config_var("myapp", "DATABASE_URL")
+        api.delete_config_var("example", "DATABASE_URL")
         stub_core
         stderr, stdout = execute("pgbackups:capture")
         stderr.should == <<-STDERR

--- a/spec/heroku/command/ps_spec.rb
+++ b/spec/heroku/command/ps_spec.rb
@@ -10,11 +10,11 @@ describe Heroku::Command::Ps do
   context("cedar") do
 
     before(:each) do
-      api.post_app("name" => "myapp", "stack" => "cedar")
+      api.post_app("name" => "example", "stack" => "cedar")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "ps:dynos errors out on cedar apps" do
@@ -29,7 +29,7 @@ describe Heroku::Command::Ps do
 
       it "displays processes" do
         Heroku::Command::Ps.any_instance.should_receive(:time_ago).exactly(10).times.and_return("2012/09/11 12:34:56 (~ 0s ago)")
-        api.post_ps_scale('myapp', 'web', 10)
+        api.post_ps_scale('example', 'web', 10)
         stderr, stdout = execute("ps")
         stderr.should == ""
         stdout.should == <<-STDOUT
@@ -50,7 +50,7 @@ STDOUT
 
       it "displays one-off processes" do
         Heroku::Command::Ps.any_instance.should_receive(:time_ago).and_return('2012/09/11 12:34:56 (~ 0s ago)', '2012/09/11 12:34:56 (~ 0s ago)')
-        api.post_ps "myapp", "bash"
+        api.post_ps "example", "bash"
 
         stderr, stdout = execute("ps")
         stderr.should == ""
@@ -139,11 +139,11 @@ STDOUT
   context("non-cedar") do
 
     before(:each) do
-      api.post_app("name" => "myapp")
+      api.post_app("name" => "example")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     describe "ps:dynos" do
@@ -153,7 +153,7 @@ STDOUT
         stderr.should == ""
         stdout.should == <<-STDOUT
 ~ `heroku ps:dynos QTY` has been deprecated and replaced with `heroku ps:scale dynos=QTY`
-myapp is running 0 dynos
+example is running 0 dynos
 STDOUT
       end
 
@@ -175,7 +175,7 @@ STDOUT
         stderr.should == ""
         stdout.should == <<-STDOUT
 ~ `heroku ps:workers QTY` has been deprecated and replaced with `heroku ps:scale workers=QTY`
-myapp is running 0 workers
+example is running 0 workers
 STDOUT
       end
 

--- a/spec/heroku/command/releases_spec.rb
+++ b/spec/heroku/command/releases_spec.rb
@@ -10,24 +10,24 @@ describe Heroku::Command::Releases do
   describe "releases" do
 
     before(:each) do
-      api.post_app("name" => "myapp", "stack" => "cedar")
-      api.put_config_vars("myapp", { 'FOO_BAR'  => 'BAZ' })
-      api.put_config_vars("myapp", { 'BAR_BAZ'  => 'QUX' })
-      api.put_config_vars("myapp", { 'BAZ_QUX'  => 'QUUX' })
-      api.put_config_vars("myapp", { 'QUX_QUUX' => 'XYZZY' })
-      api.put_config_vars("myapp", { 'SUPER_LONG_CONFIG_VAR_TO_GET_PAST_THE_TRUNCATION_LIMIT' => 'VALUE' })
+      api.post_app("name" => "example", "stack" => "cedar")
+      api.put_config_vars("example", { 'FOO_BAR'  => 'BAZ' })
+      api.put_config_vars("example", { 'BAR_BAZ'  => 'QUX' })
+      api.put_config_vars("example", { 'BAZ_QUX'  => 'QUUX' })
+      api.put_config_vars("example", { 'QUX_QUUX' => 'XYZZY' })
+      api.put_config_vars("example", { 'SUPER_LONG_CONFIG_VAR_TO_GET_PAST_THE_TRUNCATION_LIMIT' => 'VALUE' })
       Heroku::Command::Releases.any_instance.should_receive(:time_ago).exactly(5).times.and_return('2012/09/10 11:36:44 (~ 0s ago)', '2012/09/10 11:36:43 (~ 1s ago)', '2012/09/10 11:35:44 (~ 1m ago)', '2012/09/10 10:36:44 (~ 1h ago)', '2012/01/02 12:34:56')
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "should list releases" do
       @stderr, @stdout = execute("releases")
       @stderr.should == ""
       @stdout.should == <<-STDOUT
-=== myapp Releases
+=== example Releases
 v5  Config add SUPER_LONG_CONFIG_VAR_TO_GE..  email@example.com  2012/09/10 11:36:44 (~ 0s ago)
 v4  Config add QUX_QUUX                       email@example.com  2012/09/10 11:36:43 (~ 1s ago)
 v3  Config add BAZ_QUX                        email@example.com  2012/09/10 11:35:44 (~ 1m ago)
@@ -41,12 +41,12 @@ STDOUT
 
   describe "releases:info" do
     before(:each) do
-      api.post_app("name" => "myapp", "stack" => "cedar")
-      api.put_config_vars("myapp", { 'FOO_BAR' => 'BAZ' })
+      api.post_app("name" => "example", "stack" => "cedar")
+      api.put_config_vars("example", { 'FOO_BAR' => 'BAZ' })
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "requires a release to be specified" do
@@ -98,21 +98,21 @@ STDOUT
 
   describe "rollback" do
     before(:each) do
-      api.post_app("name" => "myapp", "stack" => "cedar")
-      api.put_config_vars("myapp", { 'FOO_BAR' => 'BAZ' })
-      api.put_config_vars("myapp", { 'BAR_BAZ' => 'QUX' })
-      api.put_config_vars("myapp", { 'BAZ_QUX' => 'QUUX' })
+      api.post_app("name" => "example", "stack" => "cedar")
+      api.put_config_vars("example", { 'FOO_BAR' => 'BAZ' })
+      api.put_config_vars("example", { 'BAR_BAZ' => 'QUX' })
+      api.put_config_vars("example", { 'BAZ_QUX' => 'QUUX' })
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     it "rolls back to the latest release with no argument" do
       stderr, stdout = execute("releases:rollback")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Rolling back myapp... done, v2
+Rolling back example... done, v2
 STDOUT
     end
 
@@ -120,7 +120,7 @@ STDOUT
       stderr, stdout = execute("releases:rollback v1")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Rolling back myapp... done, v1
+Rolling back example... done, v1
 STDOUT
     end
   end

--- a/spec/heroku/command/run_spec.rb
+++ b/spec/heroku/command/run_spec.rb
@@ -8,11 +8,11 @@ describe Heroku::Command::Run do
 
   before(:each) do
     stub_core
-    api.post_app("name" => "myapp", "stack" => "cedar")
+    api.post_app("name" => "example", "stack" => "cedar")
   end
 
   after(:each) do
-    api.delete_app("myapp")
+    api.delete_app("example")
   end
 
   describe "run" do
@@ -75,7 +75,7 @@ STDOUT
     end
 
     it "runs a console command" do
-      stub_core.console("myapp", "bash foo").returns("foo_output")
+      stub_core.console("example", "bash foo").returns("foo_output")
       stderr, stdout = execute("run:console bash foo")
       stderr.should == ""
       stdout.should == <<-STDOUT

--- a/spec/heroku/command/sharing_spec.rb
+++ b/spec/heroku/command/sharing_spec.rb
@@ -6,21 +6,21 @@ module Heroku::Command
 
     before(:each) do
       stub_core
-      api.post_app("name" => "myapp")
+      api.post_app("name" => "example")
     end
 
     after(:each) do
-      api.delete_app("myapp")
+      api.delete_app("example")
     end
 
     context("list") do
 
       it "lists collaborators" do
-        api.post_collaborator("myapp", "collaborator@example.com")
+        api.post_collaborator("example", "collaborator@example.com")
         stderr, stdout = execute("sharing")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp Collaborators
+=== example Collaborators
 collaborator@example.com
 email@example.com
 
@@ -33,25 +33,25 @@ STDOUT
       stderr, stdout = execute("sharing:add collaborator@example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Adding collaborator@example.com to myapp collaborators... done
+Adding collaborator@example.com to example collaborators... done
 STDOUT
     end
 
     it "removes collaborators" do
-      api.post_collaborator("myapp", "collaborator@example.com")
+      api.post_collaborator("example", "collaborator@example.com")
       stderr, stdout = execute("sharing:remove collaborator@example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Removing collaborator@example.com from myapp collaborators... done
+Removing collaborator@example.com from example collaborators... done
 STDOUT
     end
 
     it "transfers ownership" do
-      api.post_collaborator("myapp", "collaborator@example.com")
+      api.post_collaborator("example", "collaborator@example.com")
       stderr, stdout = execute("sharing:transfer collaborator@example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT
-Transferring myapp to collaborator@example.com... done
+Transferring example to collaborator@example.com... done
 STDOUT
     end
   end

--- a/spec/heroku/command/ssl_spec.rb
+++ b/spec/heroku/command/ssl_spec.rb
@@ -11,7 +11,7 @@ module Heroku::Command
       File.should_receive(:exists?).with('my.key').and_return(true)
       File.should_receive(:read).with('my.key').and_return('key contents')
       expires_at = Time.now + 60 * 60 * 24 * 365
-      stub_core.add_ssl('myapp', 'crt contents', 'key contents').returns({"domain" => "example.com", "expires_at" => expires_at})
+      stub_core.add_ssl('example', 'crt contents', 'key contents').returns({"domain" => "example.com", "expires_at" => expires_at})
       stderr, stdout = execute("ssl:add my.crt my.key")
       stderr.should == ""
       stdout.should == <<-STDOUT
@@ -20,7 +20,7 @@ STDOUT
     end
 
     it "removes certificates" do
-      stub_core.remove_ssl('myapp', 'example.com')
+      stub_core.remove_ssl('example', 'example.com')
       stderr, stdout = execute("ssl:remove example.com")
       stderr.should == ""
       stdout.should == <<-STDOUT

--- a/spec/heroku/command/stack_spec.rb
+++ b/spec/heroku/command/stack_spec.rb
@@ -6,18 +6,18 @@ module Heroku::Command
     describe "index" do
       before(:each) do
         stub_core
-        api.post_app("name" => "myapp", "stack" => "bamboo-mri-1.9.2")
+        api.post_app("name" => "example", "stack" => "bamboo-mri-1.9.2")
       end
 
       after(:each) do
-        api.delete_app("myapp")
+        api.delete_app("example")
       end
 
       it "index should provide list" do
         stderr, stdout = execute("stack")
         stderr.should == ""
         stdout.should == <<-STDOUT
-=== myapp Available Stacks
+=== example Available Stacks
   aspen-mri-1.8.6
   bamboo-ree-1.8.7
   cedar (beta)
@@ -30,7 +30,7 @@ STDOUT
         stderr, stdout = execute("stack:migrate bamboo-ree-1.8.7")
         stderr.should == ""
         stdout.should == <<-STDOUT
------> Preparing to migrate myapp
+-----> Preparing to migrate example
        bamboo-mri-1.9.2 -> bamboo-ree-1.8.7
 
        NOTE: Additional details here

--- a/spec/heroku/command_spec.rb
+++ b/spec/heroku/command_spec.rb
@@ -51,13 +51,13 @@ describe Heroku::Command do
     context "and the app is known" do
       before do
         any_instance_of(Heroku::Command::Base) do |base|
-          stub(base).app.returns("myapp")
+          stub(base).app.returns("example")
         end
       end
 
       context "and the user includes --confirm WRONGAPP" do
         it "should not allow include the option" do
-          stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+          stub_request(:post, %r{apps/example/addons/my_addon$}).
             with(:body => "")
           run "addons:add my_addon --confirm XXX"
         end
@@ -65,17 +65,17 @@ describe Heroku::Command do
 
       context "and the user includes --confirm APP" do
         it "should set --app to APP and not ask for confirmation" do
-          stub_request(:post, %r{apps/myapp/addons/my_addon$}).
-            with(:body => {:confirm => 'myapp'})
+          stub_request(:post, %r{apps/example/addons/my_addon$}).
+            with(:body => {:confirm => 'example'})
 
-          run "addons:add my_addon --confirm myapp"
+          run "addons:add my_addon --confirm example"
         end
       end
 
       context "and the user didn't include a confirm flag" do
         it "should ask the user for confirmation" do
           stub(Heroku::Command).confirm_command.returns(true)
-          stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+          stub_request(:post, %r{apps/example/addons/my_addon$}).
             to_return(response_that_requires_confirmation).then.
             to_return({:status => 200})
 
@@ -83,16 +83,16 @@ describe Heroku::Command do
         end
 
         it "should not continue if the confirmation does not match" do
-          Heroku::Command.stub(:current_options).and_return(:confirm => 'not_myapp')
+          Heroku::Command.stub(:current_options).and_return(:confirm => 'not_example')
 
           lambda do
-            Heroku::Command.confirm_command('myapp')
+            Heroku::Command.confirm_command('example')
           end.should raise_error(Heroku::Command::CommandFailed)
         end
 
         it "should not continue if the user doesn't confirm" do
           stub(Heroku::Command).confirm_command.returns(false)
-          stub_request(:post, %r{apps/myapp/addons/my_addon$}).
+          stub_request(:post, %r{apps/example/addons/my_addon$}).
             to_return(response_that_requires_confirmation).then.
             to_raise(Heroku::Command::CommandFailed)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ end
 
 def prepare_command(klass)
   command = klass.new
-  command.stub!(:app).and_return("myapp")
+  command.stub!(:app).and_return("example")
   command.stub!(:ask).and_return("")
   command.stub!(:display)
   command.stub!(:hputs)
@@ -50,7 +50,7 @@ def execute(command_line)
   object, method = Heroku::Command.prepare_run(command, args)
 
   any_instance_of(Heroku::Command::Base) do |base|
-    stub(base).app.returns("myapp")
+    stub(base).app.returns("example")
   end
 
   stub(Heroku::Auth).get_credentials.returns(['email@example.com', 'apikey01'])


### PR DESCRIPTION
Now that we have an example app up at https://example.herokuapp.com and example.herkou.com,
I'm updating dev center to use the app name `example` consistently, and @geemus suggested also updating the CLI help text to use the same app name, so this pull request will hopefully accomplish that.
