### PR TITLE
depricate heroku-sql-console

### DIFF
--- a/lib/heroku/plugin.rb
+++ b/lib/heroku/plugin.rb
@@ -19,6 +19,7 @@ module Heroku
       heroku-postgresql
       heroku-releases
       heroku-shared-postgresql
+      heroku-sql-console
       heroku-status
       heroku-stop
       heroku-suggest


### PR DESCRIPTION
Now that shen is dead, is this needed? http://stackoverflow.com/questions/13982690/heroku-not-listing-pg-search-documents-table
