### PR TITLE
added error catch if no .gitconfig exists

### DIFF
--- a/lib/heroku/command/git.rb
+++ b/lib/heroku/command/git.rb
@@ -53,6 +53,10 @@ class Heroku::Command::Git < Heroku::Command::Base
     git_options = args.join(" ")
     remote = options[:remote] || 'heroku'
 
+    unless Dir.entries(Dir.home()).include?(".gitconfig")
+      error("No .gitconfig file exists in your home directory")
+    end
+
     if git('remote').split("\n").include?(remote)
       error("Git remote #{remote} already exists")
     else


### PR DESCRIPTION
This commit fixes issue #536

It checks if .gitconfig exists in the user's home directory before checking remotes. If no .gitconfig is present, it throws an error.
