### PR TITLE
heroku run:detached --tail

### DIFF
--- a/lib/heroku/command/logs.rb
+++ b/lib/heroku/command/logs.rb
@@ -1,4 +1,5 @@
 require "heroku/command/base"
+require "heroku/helpers/log_displayer"
 
 # display logs for an app
 #
@@ -28,25 +29,8 @@ class Heroku::Command::Logs < Heroku::Command::Base
     opts << "ps=#{URI.encode(options[:ps])}"         if options[:ps]
     opts << "source=#{URI.encode(options[:source])}" if options[:source]
 
-    @assigned_colors = {}
-    @line_start = true
-    @token = nil
-
-    heroku.read_logs(app, opts) do |chunk|
-      unless chunk.empty?
-        if STDOUT.isatty && ENV.has_key?("TERM")
-          display(colorize(chunk))
-        else
-          display(chunk)
-        end
-      end
-    end
-  rescue Errno::EPIPE
-  rescue Interrupt => interrupt
-    if STDOUT.isatty && ENV.has_key?("TERM")
-      display("\e[0m")
-    end
-    raise(interrupt)
+    log_displayer = ::Heroku::Helpers::LogDisplayer.new(heroku, app, opts)
+    log_displayer.display_logs
   end
 
   # logs:drains
@@ -58,40 +42,4 @@ class Heroku::Command::Logs < Heroku::Command::Base
     display("~ `heroku logs:drains` has been deprecated and replaced with `heroku drains`")
     Heroku::Command::Drains.new.index
   end
-
-  protected
-
-  COLORS = %w( cyan yellow green magenta red )
-  COLOR_CODES = {
-    "red"     => 31,
-    "green"   => 32,
-    "yellow"  => 33,
-    "magenta" => 35,
-    "cyan"    => 36,
-  }
-
-  def colorize(chunk)
-    lines = []
-    chunk.split("\n").map do |line|
-      if parsed_line = parse_log(line)
-        header, identifier, body = parsed_line
-        @assigned_colors[identifier] ||= COLORS[@assigned_colors.size % COLORS.size]
-        lines << [
-          "\e[#{COLOR_CODES[@assigned_colors[identifier]]}m",
-          header,
-          "\e[0m",
-          body,
-        ].join("")
-      elsif not line.empty?
-        lines << line
-      end
-    end
-    lines.join("\n")
-  end
-
-  def parse_log(log)
-    return unless parsed = log.match(/^(.*?\[(\w+)([\d\.]+)?\]:)(.*)?$/)
-    [1, 2, 4].map { |i| parsed[i] }
-  end
-
 end

--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -1,5 +1,6 @@
 require "readline"
 require "heroku/command/base"
+require "heroku/helpers/log_displayer"
 
 # run one-off commands (console, rake)
 #
@@ -25,6 +26,8 @@ class Heroku::Command::Run < Heroku::Command::Base
   #
   # run a detached process, where output is sent to your logs
   #
+  # -t, --tail           # stream logs for the process
+  #
   #Example:
   #
   # $ heroku run:detached ls
@@ -41,7 +44,15 @@ class Heroku::Command::Run < Heroku::Command::Base
       status(process_data['process'])
       process_data
     end
-    display("Use `heroku logs -p #{process_data['process']}` to view the output.")
+    if options[:tail]
+      opts = []
+      opts << "tail=1"
+      opts << "ps=#{process_data['process']}"
+      log_displayer = ::Heroku::Helpers::LogDisplayer.new(heroku, app, opts)
+      log_displayer.display_logs
+    else
+      display("Use `heroku logs -p #{process_data['process']}` to view the output.")
+    end
   end
 
   # run:rake COMMAND

--- a/lib/heroku/helpers/log_displayer.rb
+++ b/lib/heroku/helpers/log_displayer.rb
@@ -1,0 +1,70 @@
+require "heroku/helpers"
+
+module Heroku::Helpers
+  class LogDisplayer
+
+    include Heroku::Helpers
+
+    attr_reader :heroku, :app, :opts
+
+    def initialize(heroku, app, opts)
+      @heroku, @app, @opts = heroku, app, opts
+    end
+
+    def display_logs
+      @assigned_colors = {}
+      @line_start = true
+      @token = nil
+
+      heroku.read_logs(app, opts) do |chunk|
+        unless chunk.empty?
+          if STDOUT.isatty && ENV.has_key?("TERM")
+            display(colorize(chunk))
+          else
+            display(chunk)
+          end
+        end
+      end
+    rescue Errno::EPIPE
+    rescue Interrupt => interrupt
+      if STDOUT.isatty && ENV.has_key?("TERM")
+        display("\e[0m")
+      end
+      raise(interrupt)
+    end
+
+    COLORS = %w( cyan yellow green magenta red )
+    COLOR_CODES = {
+      "red"     => 31,
+      "green"   => 32,
+      "yellow"  => 33,
+      "magenta" => 35,
+      "cyan"    => 36,
+    }
+
+    def colorize(chunk)
+      lines = []
+      chunk.split("\n").map do |line|
+        if parsed_line = parse_log(line)
+          header, identifier, body = parsed_line
+          @assigned_colors[identifier] ||= COLORS[@assigned_colors.size % COLORS.size]
+          lines << [
+            "\e[#{COLOR_CODES[@assigned_colors[identifier]]}m",
+            header,
+            "\e[0m",
+            body,
+          ].join("")
+        elsif not line.empty?
+          lines << line
+        end
+      end
+      lines.join("\n")
+    end
+
+    def parse_log(log)
+      return unless parsed = log.match(/^(.*?\[(\w+)([\d\.]+)?\]:)(.*)?$/)
+      [1, 2, 4].map { |i| parsed[i] }
+    end
+
+  end
+end

--- a/spec/heroku/command/run_spec.rb
+++ b/spec/heroku/command/run_spec.rb
@@ -37,6 +37,14 @@ Running `bin/foo` detached... up, run.1
 Use `heroku logs -p run.1` to view the output.
 STDOUT
     end
+
+    it "runs with options" do
+      stub_core.read_logs("example", [
+        "tail=1",
+        "ps=run.1"
+      ])
+      execute "run:detached bin/foo --tail"
+    end
   end
 
   describe "run:rake" do


### PR DESCRIPTION
Tails the logs of the run process.

Restructured the log display logic into a helper class.

Inspired by a convo with @csquared and (maybe) others.
