### PR TITLE
catch no .gitconfig when git:remote is called

### DIFF
--- a/lib/heroku/command/git.rb
+++ b/lib/heroku/command/git.rb
@@ -52,6 +52,13 @@ class Heroku::Command::Git < Heroku::Command::Base
   def remote
     git_options = args.join(" ")
     remote = options[:remote] || 'heroku'
+    current_directory = Dir.pwd
+
+    Dir.chdir
+    unless Dir.entries(Dir.pwd).include?(".gitconfig")
+      error("No .gitconfig file exists in your home directory")
+    end
+    Dir.chdir(current_directory)
 
     if git('remote').split("\n").include?(remote)
       error("Git remote #{remote} already exists")

--- a/spec/heroku/command/git_spec.rb
+++ b/spec/heroku/command/git_spec.rb
@@ -138,6 +138,28 @@ STDERR
         stdout.should == ""
       end
 
+      it "raises an error when gitconfig doesn't exist" do
+        current_dir = Dir.pwd
+        Dir.chdir
+        FileUtils.cp '.gitconfig', '.gitconfig_backup'
+        FileUtils.mv '.gitconfig', '.gitconfig_2'
+        Dir.chdir current_dir
+
+        any_instance_of(Heroku::Command::Git) do |git|
+          stub(git).git('remote').returns("heroku")
+        end
+        stderr, stdout = execute("git:remote")
+        stderr.should == <<-STDERR
+ !    No .gitconfig file exists in your home directory
+STDERR
+        stdout.should == ""
+
+        Dir.chdir
+        FileUtils.mv '.gitconfig_2', '.gitconfig'
+        FileUtils.rm '.gitconfig_backup'
+        Dir.chdir current_dir
+      end
+
     end
 
   end


### PR DESCRIPTION
This commit addresses issue #536

The fix is compatible with Ruby 1.8 and 1.9. 

I wrote a corresponding test, but it needs refactoring.  I'm new to mocks/stubs, as well as writing a test which relies on the tester's system. It doesn't seem right to be renaming the tester's gitconfig, but it does what it should.
