### PR TITLE
An authentication failure from an API key should exit 1.

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -224,7 +224,9 @@ module Heroku
       end
     rescue Heroku::API::Errors::Unauthorized, RestClient::Unauthorized
       puts "Authentication failure"
-      unless ENV['HEROKU_API_KEY']
+      if ENV['HEROKU_API_KEY']
+        exit 1
+      else
         run "login"
         retry
       end


### PR DESCRIPTION
``` bash
HEROKU_API_KEY=xx heroku run rails console --app test-app
#=> Running `rails console` attached to terminal... Authentication failure
```

The follow command should exit with a status of 1 because an authentication failure occurred that it could not recover from.
