### PR TITLE
Sync up console deprecation with rake deprecation

### DIFF
--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -91,12 +91,11 @@ class Heroku::Command::Run < Heroku::Command::Base
   # >>
   #
   def console
-    puts "`heroku #{current_command}` has been removed. Please use: `heroku run` instead."
-    puts "For more information, please see:"
-    puts " * https://devcenter.heroku.com/articles/one-off-dynos"
-    puts " * https://devcenter.heroku.com/articles/rails3#console"
-    puts " * https://devcenter.heroku.com/articles/console-bamboo"
+    deprecate("`heroku #{current_command}` has been deprecated. Please use `heroku run rake` instead.")
+    command = "console #{args.join(' ')}"
+    run_attached(command)
   end
+
   alias_command "console", "run:console"
 
 protected
@@ -132,49 +131,5 @@ protected
     ensure
       set_buffer(true)
     end
-  end
-
-  def console_history_dir
-    FileUtils.mkdir_p(path = "#{home_directory}/.heroku/console_history")
-    path
-  end
-
-  def console_session(app)
-    heroku.console(app) do |console|
-      console_history_read(app)
-
-      display "Ruby console for #{app}.#{heroku.host}"
-      while cmd = Readline.readline('>> ')
-        unless cmd.nil? || cmd.strip.empty?
-          console_history_add(app, cmd)
-          break if cmd.downcase.strip == 'exit'
-          display console.run(cmd)
-        end
-      end
-    end
-  end
-
-  def console_history_file(app)
-    "#{console_history_dir}/#{app}"
-  end
-
-  def console_history_read(app)
-    history = File.read(console_history_file(app)).split("\n")
-    if history.size > 50
-      history = history[(history.size - 51),(history.size - 1)]
-      File.open(console_history_file(app), "w") { |f| f.puts history.join("\n") }
-    end
-    history.each { |cmd| Readline::HISTORY.push(cmd) }
-  rescue Errno::ENOENT
-  rescue Exception => ex
-    display "Error reading your console history: #{ex.message}"
-    if confirm("Would you like to clear it? (y/N):")
-      FileUtils.rm(console_history_file(app)) rescue nil
-    end
-  end
-
-  def console_history_add(app, cmd)
-    Readline::HISTORY.push(cmd)
-    File.open(console_history_file(app), "a") { |f| f.puts cmd + "\n" }
   end
 end

--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -91,7 +91,7 @@ class Heroku::Command::Run < Heroku::Command::Base
   # >>
   #
   def console
-    deprecate("`heroku #{current_command}` has been deprecated. Please use `heroku run rake` instead.")
+    deprecate("`heroku #{current_command}` has been deprecated. Please use `heroku run console` instead.")
     command = "console #{args.join(' ')}"
     run_attached(command)
   end


### PR DESCRIPTION
Normalize the approach to console with rake. Run it, but spit out a deprecation message.

![HATERS](https://f.cloud.github.com/assets/60851/211124/b4dd7104-82aa-11e2-9803-3cc7dbf13d22.jpg)
