### PR TITLE
v2.36.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroku (2.36.0.pre)
+    heroku (2.36.0)
       heroku-api (~> 0.3.7)
       launchy (>= 0.3.2)
       netrc (~> 0.7.7)
@@ -25,7 +25,7 @@ GEM
     clamp (0.5.0)
     crack (0.3.2)
     diff-lcs (1.1.3)
-    excon (0.16.10)
+    excon (0.20.1)
     fakefs (0.4.2)
     fpm (0.4.6)
       arr-pm (~> 0.0.7)
@@ -33,8 +33,8 @@ GEM
       cabin (~> 0.4.3)
       clamp
       json
-    heroku-api (0.3.7)
-      excon (~> 0.16.10)
+    heroku-api (0.3.9)
+      excon (~> 0.20.1)
     json (1.7.7)
     launchy (2.2.0)
       addressable (~> 2.3)
@@ -58,6 +58,7 @@ GEM
     sinatra (1.0)
       rack (>= 1.0)
     sqlite3 (1.3.7)
+    sqlite3 (1.3.7-x86-mingw32)
     taps (0.3.24)
       rack (>= 1.0.1)
       rest-client (>= 1.4.0, < 1.7.0)

--- a/lib/heroku/version.rb
+++ b/lib/heroku/version.rb
@@ -1,3 +1,3 @@
 module Heroku
-  VERSION = "2.36.0.pre"
+  VERSION = "2.36.0"
 end


### PR DESCRIPTION
Bump version to v2.36.0. Public release of `heroku fork` functionality.
