### PR TITLE
Use the recommended SSL URL for RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
I'm guessing there might be a reason why you guys aren't doing this but I'm not aware of it.
