### PR TITLE
Allow Heroku::Command::Run to be used in threaded application be specifying alternative IO.

### DIFF
--- a/lib/heroku/command/run.rb
+++ b/lib/heroku/command/run.rb
@@ -126,8 +126,8 @@ protected
         :rendezvous_url => rendezvous_url,
         :connect_timeout => (ENV["HEROKU_CONNECT_TIMEOUT"] || 120).to_i,
         :activity_timeout => nil,
-        :input => $stdin,
-        :output => $stdout)
+        :input => options[:input] || $stdin,
+        :output => options[:output] || $stdout)
       rendezvous.on_connect(&on_connect)
       rendezvous.start
     rescue Timeout::Error


### PR DESCRIPTION
This allows you specific different IO objects for the input and outputs of run
command. Specifically useful when trying to use the Heroku::Command::Run in a
threaded environment where $stdin and $stdout can not be overridden.
