### PR TITLE
Send command options when listing add-ons

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -546,8 +546,10 @@ Check the output of "heroku ps" and "heroku logs" for more information.
     delete("/apps/#{app_name}/logs/drains?url=#{URI.escape(url)}").to_s
   end
 
-  def addons
-    json_decode get("/addons", :accept => 'application/json').to_s
+  def addons(filters = {})
+    url = "/addons"
+    params = filters.map{|k,v| "#{k}=#{v}"}.join("&")
+    json_decode get([url,params].join("?"), :accept => 'application/json').to_s
   end
 
   def installed_addons(app_name)

--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -43,7 +43,8 @@ module Heroku::Command
     # list all available addons
     #
     def list
-      addons = heroku.addons
+      config = parse_options(args)
+      addons = heroku.addons(config)
       if addons.empty?
         display "No addons available currently"
       else

--- a/spec/heroku/command/addons_spec.rb
+++ b/spec/heroku/command/addons_spec.rb
@@ -60,7 +60,14 @@ STDOUT
     end
 
     describe "list" do
-      before do
+
+      it "sends options to the server" do
+        stub_request(:get, %r{/addons\?foo=bar$}).
+          to_return(:body => Heroku::OkJson.encode([]))
+        execute("addons:list --foo=bar")
+      end
+
+      it "lists available addons" do
         stub_core.addons.returns([
           { "name" => "cloudcounter:basic", "state" => "alpha" },
           { "name" => "cloudcounter:pro", "state" => "public" },
@@ -68,9 +75,6 @@ STDOUT
           { "name" => "cloudcounter:old", "state" => "disabled" },
           { "name" => "cloudcounter:platinum", "state" => "beta" }
         ])
-      end
-
-      it "lists available addons" do
         stderr, stdout = execute("addons:list")
         stderr.should == ""
         stdout.should == <<-STDOUT


### PR DESCRIPTION
Adding in support to provide options on the CLI to filter the list of add-ons returned, required for heroku/addons#672

/cc @geemus would you mind taking a look at this? I couldn't see a good existing example of how to test it, what I've got feels inconsistent with the rest of the suite.
