### PR TITLE
Fix Cisaurus.job_done? to continue to poll while 202

### DIFF
--- a/lib/heroku/client/cisaurus.rb
+++ b/lib/heroku/client/cisaurus.rb
@@ -20,7 +20,6 @@ class Heroku::Client::Cisaurus
   end
 
   def job_done?(job_location)
-    done = authenticated_resource(job_location).get.code
-    done == 202
+    202 != authenticated_resource(job_location).get.code
   end
 end


### PR DESCRIPTION
Cisaurus returned a 202 while jobs are still in progress, so reversing the equality on `job_done?`. I did local testing with non-200 final responses and RestClient handles them correctly (i.e. showing the value of the `error` key of the returned hash).
