### PR TITLE
Allow app names to be case-insensitive

### DIFF
--- a/lib/heroku/command/base.rb
+++ b/lib/heroku/command/base.rb
@@ -25,7 +25,7 @@ class Heroku::Command::Base
       end
       options[:confirm]
     elsif options[:app].is_a?(String)
-      options[:app]
+      options[:app].downcase
     elsif ENV.has_key?('HEROKU_APP')
       ENV['HEROKU_APP']
     elsif app_from_dir = extract_app_in_dir(Dir.pwd)

--- a/spec/heroku/command/base_spec.rb
+++ b/spec/heroku/command/base_spec.rb
@@ -47,6 +47,11 @@ STDERR
         @base.app.should == "example"
       end
 
+      it "attempts to find the app via the --app option case-insensitively" do
+        @base.stub!(:options).and_return(:app => "ExAmPlE")
+        @base.app.should == "example"
+      end
+
       it "attempts to find the app via the --confirm option" do
         @base.stub!(:options).and_return(:confirm => "myconfirmapp")
         @base.app.should == "myconfirmapp"


### PR DESCRIPTION
Given that application names are lowercase always:

```
$  heroku create Foo                                                                                                                     
 !    Name must start with a letter and can only contain lowercase letters, numbers, and dashes.
```

It's fair that the CLI should force downcasing of app names when using `--app` or `-a`.

I've hit this a few times when taking app names from email/tickets etc that have a leading capital character.
