### PR TITLE
Don't fail silently if setting a remote outside of git

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -154,7 +154,7 @@ module Heroku
 
     def create_git_remote(remote, url)
       return if git('remote').split("\n").include?(remote)
-      return unless File.exists?(".git")
+      error("Not a git repository") and return unless File.exists?(".git")
       git "remote add #{remote} #{url}"
       display "Git remote #{remote} added"
     end


### PR DESCRIPTION
Currently `git:remote` fails when used outside of a repo.  This fixes that.

```
$  heroku git:remote -a neilmiddleton                                                                                                           
 !    Not a git repository!
```
