### PR TITLE
enable Windows users to specify an alternate home directory

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -6,7 +6,7 @@ module Heroku
     extend self
 
     def home_directory
-      running_on_windows? ? ENV['USERPROFILE'].gsub("\\","/") : ENV['HOME']
+      running_on_windows? ? (ENV['HEROKU_HOME'] || ENV['USERPROFILE']).gsub("\\","/") : ENV['HOME']
     end
 
     def running_on_windows?


### PR DESCRIPTION
The toolbelt would not work on Windows if the user has an account name with non-English letters in it (such as Latin-1, etc.); even though this is perfectly valid in Windows.

With this change the user can specify a HEROKU_HOME environment variable to be used as home directory for the toolbelt (which falls back to the standard USERPROFILE). If this directory has only English ASCII characters in it the toolbelt starts to work just fine.
