### PR TITLE
Send EOF to the remote on input EOF

### DIFF
--- a/lib/heroku/client/rendezvous.rb
+++ b/lib/heroku/client/rendezvous.rb
@@ -56,6 +56,8 @@ class Heroku::Client::Rendezvous
             begin
               data = input.readpartial(10000)
             rescue EOFError
+              ssl_socket.write(4.chr)
+              ssl_socket.flush
               readables.delete(input)
               next
             end


### PR DESCRIPTION
Attached patch sends 4.chr to the remote on input EOF. It finally makes it possible to pipe stuff to heroku run. Fixes issue #256
