### PR TITLE
Better HEROKU_POSTGRESQL_HOST env var handling for staging

### DIFF
--- a/lib/heroku/client/heroku_postgresql.rb
+++ b/lib/heroku/client/heroku_postgresql.rb
@@ -23,12 +23,12 @@ class Heroku::Client::HerokuPostgresql
 
   def heroku_postgresql_host
     if attachment.starter_plan?
-      ENV["HEROKU_POSTGRESQL_HOST"] || "postgres-starter-api"
+      determine_host(ENV["HEROKU_POSTGRESQL_HOST"], "postgres-starter-api.heroku.com")
     else
       if ENV['SHOGUN']
-        "shogun-#{ENV['SHOGUN']}"
+        "shogun-#{ENV['SHOGUN']}.herokuapp.com"
       else
-        ENV["HEROKU_POSTGRESQL_HOST"] || "postgres-api"
+        determine_host(ENV["HEROKU_POSTGRESQL_HOST"], "postgres-api.heroku.com")
       end
     end
   end
@@ -39,7 +39,7 @@ class Heroku::Client::HerokuPostgresql
 
   def heroku_postgresql_resource
     RestClient::Resource.new(
-      "https://#{heroku_postgresql_host}.heroku.com/client/v11/databases",
+      "https://#{heroku_postgresql_host}/client/v11/databases",
       :user => Heroku::Auth.user,
       :password => Heroku::Auth.password,
       :headers => self.class.headers
@@ -124,6 +124,16 @@ class Heroku::Client::HerokuPostgresql
       response = heroku_postgresql_resource[path].put(json_encode(payload))
       display_heroku_warning response
       sym_keys(json_decode(response.to_s))
+    end
+  end
+
+  private
+
+  def determine_host(value, default)
+    if value.nil?
+      default
+    else
+      "#{value}.herokuapp.com"
     end
   end
 end


### PR DESCRIPTION
Because Shogun staging environments are now set up on herokuapp.com
and RestClient doesn't follow 301s, that means some commands (like
`heroku pg:reset` and `heroku pg:credentials --reset`) don't work in
staging. This change always points to herokuapp.com for staging.
