### PR TITLE
Support alphanumeric process ids

### DIFF
--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -115,7 +115,11 @@ class Heroku::Command::Ps < Heroku::Command::Base
     extract_run_id = /\.(\d+).*:/
     processes_by_command.keys.each do |key|
       processes_by_command[key] = processes_by_command[key].sort do |x,y|
-        x.match(extract_run_id).captures.first.to_i <=> y.match(extract_run_id).captures.first.to_i
+        begin
+          x.match(extract_run_id).captures.first.to_i <=> y.match(extract_run_id).captures.first.to_i
+        rescue
+          0
+        end
       end
     end
 


### PR DESCRIPTION
If process names have alphanumeric ids, `heroku ps` crashes when trying to sort them. The desired output is:

```
$ heroku ps
=== web (1X): `bundle exec rackup -s thin -p $PORT`
web.0ac72f69: up 2013/06/11 19:21:47 (~ 0s ago)
web.5c560432: up 2013/06/11 19:21:47 (~ 0s ago)
```

This change prevents processes with non-integer ids to be sorted.
