### PR TITLE
heroku logs --tail doesnt work when the output is sent through a pipe

### DIFF
--- a/lib/heroku/helpers/log_displayer.rb
+++ b/lib/heroku/helpers/log_displayer.rb
@@ -18,16 +18,17 @@ module Heroku::Helpers
 
       heroku.read_logs(app, opts) do |chunk|
         unless chunk.empty?
-          if STDOUT.isatty && ENV.has_key?("TERM")
+          if $stdout.isatty && ENV.has_key?("TERM")
             display(colorize(chunk))
           else
             display(chunk)
+            $stdout.flush
           end
         end
       end
     rescue Errno::EPIPE
     rescue Interrupt => interrupt
-      if STDOUT.isatty && ENV.has_key?("TERM")
+      if $stdout.isatty && ENV.has_key?("TERM")
         display("\e[0m")
       end
       raise(interrupt)

--- a/spec/heroku/command/logs_spec.rb
+++ b/spec/heroku/command/logs_spec.rb
@@ -24,25 +24,19 @@ describe Heroku::Command::Logs do
       end
 
       it "prettifies tty output" do
-        old_stdout_isatty = $stdout.isatty
-        stub($stdout).isatty.returns(true)
-        stderr, stdout = execute("logs")
+        stderr, stdout = execute("logs") { |sin, sout, serr| sout.stub!(:isatty).and_return(true) }
         stderr.should == ""
         stdout.should == <<-STDOUT
 \e[36m2011-01-01T00:00:00+00:00 app[web.1]:\e[0m test
 STDOUT
-        stub($stdout).isatty.returns(old_stdout_isatty)
       end
 
       it "does not use ansi if stdout is not a tty" do
-        old_stdout_isatty = $stdout.isatty
-        stub($stdout).isatty.returns(false)
-        stderr, stdout = execute("logs")
+        stderr, stdout = execute("logs") { |sin, sout, serr| sout.stub!(:isatty).and_return(false) }
         stderr.should == ""
         stdout.should == <<-STDOUT
 2011-01-01T00:00:00+00:00 app[web.1]: test
 STDOUT
-        stub($stdout).isatty.returns(old_stdout_isatty)
       end
 
       it "does not use ansi if TERM is not set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ def prepare_command(klass)
   command
 end
 
-def execute(command_line)
+def execute(command_line, &block)
   extend RR::Adapters::RRMethods
 
   args = command_line.split(" ")
@@ -66,6 +66,8 @@ def execute(command_line)
       true
     end
   end
+
+  yield $stdin, $stdout, $stderr if block_given?
 
   begin
     object.send(method)


### PR DESCRIPTION
```
heroku logs -t | cat
```

This command will not print any new output from the application, effectively ignoring the -t option.
