### PR TITLE
Like Excon itself, don't ssl_verify_peer on Windows systems

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -1,3 +1,4 @@
+require "rbconfig"
 require "cgi"
 require "heroku"
 require "heroku/client"
@@ -332,7 +333,8 @@ class Heroku::Auth
         :host             => uri.host,
         :port             => uri.port.to_s,
         :scheme           => uri.scheme,
-        :ssl_verify_peer  => verify_host?(host)
+        :ssl_verify_peer  => verify_host?(host) &&
+          RbConfig::CONFIG['host_os'] !~ /mswin|win32|dos|cygwin|mingw/i,
       }
     end
   end


### PR DESCRIPTION
I've gotten some support tickets related to SSL verification on Windows
systems, and _I think_ this is a possible fix.

See https://github.com/geemus/excon/blob/master/lib/excon.rb#L38.

/cc @geemus
