### PR TITLE
Fixes #832

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -201,13 +201,13 @@ module Heroku
     end
 
     def self.run(cmd, arguments=[])
-      begin
+     require 'heroku-api'
+     require 'rest_client'
+     begin
         object, method = prepare_run(cmd, arguments.dup)
         object.send(method)
       rescue Interrupt, StandardError, SystemExit => error
         # load likely error classes, as they may not be loaded yet due to defered loads
-        require 'heroku-api'
-        require 'rest_client'
         raise(error)
       end
     rescue Heroku::API::Errors::Unauthorized, RestClient::Unauthorized


### PR DESCRIPTION
The `rescue` commands pertaining to `self.run` trigger errors when the `heroku-gem` is used rather than `heroku-toolbelt`.This is a small change that fixes the behaviour. Atleast until the time the installation of the `heroku` gem is completely stopped, I think we need to cover the edge cases. That said, I won't mind if this is rejected :)

This is my first PR to this repo and so, if I need to change anything, do let me know. 
