### PR TITLE
add support for showing process types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.39.5 2013-07-11
+=================
+add ps:types for retrieving process types
+
 2.39.4 2013-05-29
 =================
 only show app region on heroku create when specified

--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.files = %x{ git ls-files }.split("\n").select { |d| d =~ %r{^(License|README|bin/|data/|ext/|lib/|spec/|test/)} }
 
-  gem.add_dependency "heroku-api",  "~> 0.3.7"
+  gem.add_dependency "heroku-api",  "~> 0.3.15"
   gem.add_dependency "netrc",       "~> 0.7.7"
   gem.add_dependency "rest-client", "~> 1.6.1"
   gem.add_dependency "launchy",     ">= 0.3.2"

--- a/lib/heroku/command/ps.rb
+++ b/lib/heroku/command/ps.rb
@@ -198,6 +198,24 @@ class Heroku::Command::Ps < Heroku::Command::Base
 
   alias_command "scale", "ps:scale"
 
+
+  # ps:types
+  #
+  # lists process types defined in the app
+  #
+  # Example:
+  #
+  # $ heroku types
+  # web
+  # worker
+  #
+  def types
+    types = api.get_types(app).body
+    types.each do |type|
+      display type["name"]
+    end
+  end
+
   # ps:stop DYNOS
   #
   # stop an app dyno

--- a/lib/heroku/version.rb
+++ b/lib/heroku/version.rb
@@ -1,3 +1,3 @@
 module Heroku
-  VERSION = "2.39.4"
+  VERSION = "2.39.5"
 end

--- a/spec/heroku/command/ps_spec.rb
+++ b/spec/heroku/command/ps_spec.rb
@@ -134,6 +134,18 @@ STDOUT
 
     end
 
+    describe "ps:types" do
+
+      it "displays the process types for an app" do
+        stderr, stdout = execute("ps:types")
+        stderr.should == ""
+        stdout.should == <<-STDOUT
+console
+STDOUT
+      end
+
+    end  
+
   end
 
   context("non-cedar") do


### PR DESCRIPTION
This adds client support for displaying process types for an app. 

It requires a bump in the heroku-api gem for it can be merged - the pull request is here:
https://github.com/heroku/heroku.rb/pull/66

Let me know if I got any of this right/wrong - first time...
