### PR TITLE
Set Git user and email for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ rvm:
   - 1.9.2
   - 1.9.3
 
+before_install:
+  - git config --global user.name "Travis CI"
+  - git config --global user.email "user@example.com"
+
 script: bundle exec rspec -bfs spec


### PR DESCRIPTION
Travis is useless if every build fails. This pull request fixes that.

Because of the way that Travis CI is set up, the Git user isn't
configured for committing (user.name, user.email). Explicitly setting
user.name and user.email variables ensures that the tests involving Git
don't fail due to problems with Travis.

To see more information about the error, see the [Git FAQ](https://git.wiki.kernel.org/index.php/Git_FAQ#Git_commit_is_dying_telling_me_.22fatal:_empty_ident_.3Cuser.40myhost.3E_not_allowed.22.2C_what.27s_wrong.3F)
and travis-ci/travis-cookbooks#159.

See the [finally passing Travis build](https://travis-ci.org/benmanns/heroku/builds/9566154) and &darr;.
