### PR TITLE
Ensure stdout is flushed whenever we want to display something

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -22,8 +22,8 @@ module Heroku
         puts(msg)
       else
         print(msg)
-        $stdout.flush
       end
+      $stdout.flush
     end
 
     def redisplay(line, line_break = false)


### PR DESCRIPTION
I'm not sure why this is required as `$stdout.sync == true` inside the heroku cli, but I'm seeing buffered output with the following command (tee's output is un-buffered):

``` bash
heroku logs --tail | tee tmp
```

However without a pipe the output appears un-buffered:

``` bash
heroku logs --tail
```

The only difference I can see in the code paths is that control characters are included via `colorize` when displaying to a tty.

I'm unable to re-produce this behavior in a simple [test script](https://gist.github.com/mikehale/df9ad611fe626638761d) using the same version of ruby used by my toolbelt (1.9.3-p194), so I'm not really sure what is going on. I wanted to go ahead and report this in case someone else had ideas.

The changes below do resolve the buffering issue for `heroku logs --tail | tee tmp`.
