### PR TITLE
Prevent redundant API call when using pg:info

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -332,7 +332,12 @@ private
 
     @resolver = generate_resolver
     dbs = @resolver.all_databases
-    @hpg_databases_with_info = Hash[ dbs.map { |config, att| [att.display_name, hpg_info(att, options[:extended])] } ]
+
+    @hpg_databases_with_info = Hash[ 
+      dbs.reject{|config, att| 'DATABASE_URL' == config}.map do |config, att|
+        [att.display_name, hpg_info(att, options[:extended])] 
+      end
+    ]
 
     return @hpg_databases_with_info
   end


### PR DESCRIPTION
Because of the way [database add-ons are collected](https://github.com/heroku/heroku/blob/master/lib/heroku/helpers/heroku_postgresql.rb#L91-L102), you end up with a duplicate
for the `DATABASE_URL` database. The client then goes on and asks API for information on all these databases, including asking about the duplicate database. If you have 2 databases, it makes 3 API calls.

This update rejects that entry, and only hits the API once for each database add-on.

Before:

``` bash
$ bin/heroku pg:info -a puma-example
RestClient.get "https://***"
# => 200 OK | text/html 556 bytes
RestClient.get "https://***"
# => 200 OK | text/html 571 bytes
RestClient.get "https://***"
# => 200 OK | text/html 571 bytes
=== HEROKU_POSTGRESQL_IVORY_URL (DATABASE_URL)
Plan:        Crane
[...]

=== HEROKU_POSTGRESQL_ONYX_URL
Plan:        Dev
[...]
```

After:

``` bash
$ bin/heroku pg:info -a puma-example
RestClient.get "https://***"
# => 200 OK | text/html 556 bytes
RestClient.get "https://***"
# => 200 OK | text/html 571 bytes
=== HEROKU_POSTGRESQL_IVORY_URL (DATABASE_URL)
Plan:        Crane
[...]

=== HEROKU_POSTGRESQL_ONYX_URL
Plan:        Dev
[…]
```
