### PR TITLE
Only loop through databases once

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -334,7 +334,8 @@ private
     dbs = @resolver.all_databases
 
     @hpg_databases_with_info = Hash[ 
-      dbs.reject{|config, att| 'DATABASE_URL' == config}.map do |config, att|
+      dbs.map do |config, att|
+        next if 'DATABASE_URL' == config
         [att.display_name, hpg_info(att, options[:extended])] 
       end
     ]


### PR DESCRIPTION
When mapping databases for API calls, only loop through the list once. 

Realized we were looping through the array 2x as of heroku/heroku#928 only after it was merged :panda_face: 
