### PR TITLE
Show HEROKU_POSTGRESQL_COLOR name when connecting via pg:psql

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -82,7 +82,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
       if command = options[:command]
         command = "-c '#{command}'"
       end
-      puts "---> Connecting to #{attachment.addon_name}"
+      puts "---> Connecting to #{attachment.display_name}"
       exec "psql -U #{uri.user} -h #{uri.host} -p #{uri.port || 5432} #{command} #{uri.path[1..-1]}"
     rescue Errno::ENOENT
       output_with_bang "The local psql command could not be located"

--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -23,10 +23,6 @@ module Heroku::Helpers::HerokuPostgresql
       config_var + (primary_attachment? ? " (DATABASE_URL)"  : '')
     end
 
-    def addon_name
-      @raw['name'].gsub(/_URL/, '')
-    end
-
     def primary_attachment!
       @primary_attachment = true
     end


### PR DESCRIPTION
Show the name of the Heroku Postgres database you're connecting to:

``` bash
$ heroku pg:psql HEROKU_POSTGRESQL_GRAY -a app
---> Connecting to HEROKU_POSTGRESQL_GRAY
psql (9.2.4, server 9.2.5)
SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
Type "help" for help.

ec2-54-***-***-5 => \q

$ heroku heroku pg:psql -a app
---> Connecting to HEROKU_POSTGRESQL_ROSE_URL (DATABASE_URL)
Expanded display is used automatically.
Timing is on.
psql (9.2.4)
SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
Type "help" for help.

ec2-54-***-***-169 => \q
```
