### PR TITLE
Permit the usage of ENV["PGPORT"] to change localhost port

### DIFF
--- a/lib/heroku/helpers/pg_dump_restore.rb
+++ b/lib/heroku/helpers/pg_dump_restore.rb
@@ -75,7 +75,7 @@ class PgDumpRestore
   def fill_in_shorthand_uris!
     [@target, @source].each do |uri|
       uri.host ||= 'localhost'
-      uri.port ||= 5432
+      uri.port ||= Integer(ENV['PGPORT'] || 5432)
     end
   end
 

--- a/spec/helper/pg_dump_restore_spec.rb
+++ b/spec/helper/pg_dump_restore_spec.rb
@@ -12,6 +12,11 @@ describe PgDumpRestore, 'pull' do
     expect { PgDumpRestore.new(@remotedb, @localdb, mock) }.to_not raise_error
   end
 
+  it 'uses PGPORT from ENV to set local port' do
+    ENV['PGPORT'] = '15432'
+    expect(PgDumpRestore.new(@remotedb, @localdb, mock).instance_variable_get('@target').port).to eq 15432
+  end
+
   it 'on pulls, prepare requires the local database to not exist' do
     mock_command = mock
     mock_command.should_receive(:error).once


### PR DESCRIPTION
Using boxen to configure my machine, I can't use this feature to dump and restore in one command with the heroku client.

Postgres is not running on a 5432 port but on the 15432. And it is impossible to pass a specific port to that part of the code.
