### PR TITLE
Chomp trailing _URL when removing Heroku Postgresql databases

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -103,6 +103,9 @@ module Heroku::Command
 
       args.each do |name|
         messages = nil
+        if name.start_with? "HEROKU_POSTGRESQL_"
+          name = name.chomp("_URL").freeze
+        end
         action("Removing #{name} on #{app}") do
           messages = addon_run { heroku.uninstall_addon(app, name, :confirm => app) }
         end


### PR DESCRIPTION
Make `HEROKU_POSTGRESQL_BRONZE_URL` valid instead of insisting on
`HEROKU_POSTGRESQL_BRONZE`

Output before:

```
$ heroku addons:remove HEROKU_POSTGRESQL_BRONZE_URL -a test-thing 

 !    WARNING: Destructive Action
 !    This command will affect the app: test-thing
 !    To proceed, type "test-thing" or re-run this command with --confirm test-thing

> test-thing
Removing HEROKU_POSTGRESQL_BRONZE_URL on test-thing... failed
 !    AddonPlan not found.
```

After (the `bin/` is from my local checkout):

```
$ bin/heroku addons:remove HEROKU_POSTGRESQL_BRONZE_URL -a test-thing                                                          

 !    WARNING: Destructive Action
 !    This command will affect the app: test-thing
 !    To proceed, type "test-thing" or re-run this command with --confirm test-thing

> test-thing
Removing HEROKU_POSTGRESQL_BRONZE on test-thing... done, v119 ($50/mo)
```
