### PR TITLE
Atomically scale+resize in a single call

### DIFF
--- a/spec/heroku/command/ps_spec.rb
+++ b/spec/heroku/command/ps_spec.rb
@@ -132,7 +132,8 @@ STDOUT
       it "can scale multiple types in one call" do
         Excon.stub({ :method => :patch, :path => "/apps/example/formation" },
                    { :body => [{"quantity" => 4, "size" => 1, "type" => "web"},
-                               {"quantity" => 2, "size" => 2, "type" => "worker"}],
+                               {"quantity" => 2, "size" => 2, "type" => "worker"},
+                               {"quantity" => 0, "size" => 1, "type" => "dummy"}],
                      :status => 200})
         stderr, stdout = execute("ps:scale web=4:1X worker=2:2X")
         stderr.should == ""


### PR DESCRIPTION
Making scale+resize in two separate calls can lead to a window in which new dedicated dynos get spun up (causing new runtime nodes to be booted) only to be immediately terminated again once the second call lands. This collapses it into a single API call. Unfortunately the collapsed API call is only in the V3 API, so we can't use the `heroku-api` gem's methods.
