### PR TITLE
pg:info raises warning with ruby 2.0 when building hash from array with nil values

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -339,7 +339,7 @@ private
       dbs.map do |config, att|
         next if 'DATABASE_URL' == config
         [att.display_name, hpg_info(att, options[:extended])] 
-      end
+      end.compact
     ]
 
     return @hpg_databases_with_info


### PR DESCRIPTION
Ruby 2.0 raises a warning when trying to build a hash from an array with nil values. 

```
> heroku pg:info --app quikly-prod
.heroku/client/lib/heroku/command/pg.rb:338: warning: wrong element type nil at 1 (expected array)
.heroku/client/lib/heroku/command/pg.rb:338: warning: ignoring wrong elements is deprecated, remove them explicitly
.heroku/client/lib/heroku/command/pg.rb:338: warning: this causes ArgumentError in the next release
```

This pull request just compacts the array before creating a hash from it.
