### PR TITLE
Don't wait_for_db on Postgres 2.0 hobby plans; remove unused #pg_api param.

### DIFF
--- a/lib/heroku/command/fork.rb
+++ b/lib/heroku/command/fork.rb
@@ -61,7 +61,7 @@ module Heroku::Command
           from_config.delete(from_var_name)
 
           plan = addon["name"].split(":").last
-          unless %w(dev basic).include? plan
+          unless %w(dev basic hobby-dev hobby-basic).include? plan
             wait_for_db to, to_addon
           end
 
@@ -133,8 +133,8 @@ module Heroku::Command
       end
     end
 
-    def pg_api(starter=false)
-      host = starter ? "postgres-starter-api.heroku.com" : "postgres-api.heroku.com"
+    def pg_api
+      host = "postgres-api.heroku.com"
       RestClient::Resource.new "https://#{host}/client/v11/databases", Heroku::Auth.user, Heroku::Auth.password
     end
 


### PR DESCRIPTION
Forking apps with Postgres 2.0 "Hobby" plans attached was failing because we were _wrongly_ querying their `wait_status` against `postgres-api.heroku.com`.
