### PR TITLE
Fix ruby2.0 Hash[nil] deprecated warnings in pg.rb

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -335,11 +335,11 @@ private
     @resolver = generate_resolver
     dbs = @resolver.all_databases
 
-    @hpg_databases_with_info = Hash[ 
+    @hpg_databases_with_info = Hash[
       dbs.map do |config, att|
         next if 'DATABASE_URL' == config
-        [att.display_name, hpg_info(att, options[:extended])] 
-      end
+        [att.display_name, hpg_info(att, options[:extended])]
+      end.compact
     ]
 
     return @hpg_databases_with_info


### PR DESCRIPTION
In Ruby 2.0, we get warnings on STDERR. Which will be ArgumentError later.

```
warning: wrong element type nil at 3 (expected array)
warning: ignoring wrong elements is deprecated, remove them explicitly
warning: this causes ArgumentError in the next release
```
