### PR TITLE
Fix wrong element warnings coming from pg command

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -333,14 +333,13 @@ private
     return @hpg_databases_with_info if @hpg_databases_with_info
 
     @resolver = generate_resolver
-    dbs = @resolver.all_databases
 
-    @hpg_databases_with_info = Hash[ 
-      dbs.map do |config, att|
-        next if 'DATABASE_URL' == config
-        [att.display_name, hpg_info(att, options[:extended])] 
-      end
-    ]
+    dbs_with_info = @resolver.all_databases.map do |config, att|
+      next if 'DATABASE_URL' == config
+      [att.display_name, hpg_info(att, options[:extended])] 
+    end
+
+    @hpg_databases_with_info = Hash[dbs_with_info.compact]
 
     return @hpg_databases_with_info
   end


### PR DESCRIPTION
Calling `Hash::[]` with an array containing nil will output warnings on Ruby 2.x:

```
.../command/pg.rb:338: warning: wrong element type nil at 1 (expected array)
.../command/pg.rb:338: warning: ignoring wrong elements is deprecated, remove them explicitly
.../command/pg.rb:338: warning: this causes ArgumentError in the next release
```

Fix by calling #compact on the array to remove the nils.
