### PR TITLE
Fix duplicate gem warning in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,13 @@ source "http://rubygems.org"
 
 gemspec
 
-group :development do
-  gem "aws-s3"
+group :development, :test do
   gem "rake",  ">= 0.8.7"
   gem "rr",    "~> 1.0.2"
+end
+
+group :development do
+  gem "aws-s3"
   gem "fpm"
   gem "rubyzip"
 end
@@ -14,8 +17,6 @@ group :test do
   gem "fakefs"
   gem "jruby-openssl", :platform => :jruby
   gem "json"
-  gem "rake",  ">= 0.8.7"
-  gem "rr",    "~> 1.0.2"
   gem "rspec", ">= 2.0"
   gem "sqlite3"
   gem "webmock"


### PR DESCRIPTION
Group `:development` and `:test` both had `rr` and `rake` pegged at the same
version, and Bundler was complaining:

```
$ bundle 
Your Gemfile lists the gem rake (>= 0.8.7) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
Your Gemfile lists the gem rr (~> 1.0.2) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```

This commit breaks them out into their own block. Personally I'd lump everything into the `group :development, :test` block, but I may be unaware of reasons to keep them separate. 
