### PR TITLE
heroku sharing:{add,remove} manager API fixes

### DIFF
--- a/lib/heroku/client/organizations.rb
+++ b/lib/heroku/client/organizations.rb
@@ -137,11 +137,19 @@ class Heroku::Client::Organizations
 
     def post_collaborator(org, app, user)
       api.request(
-        :expects => 201,
+        :expects => 200,
         :method => :post,
-        :path => "v1/organization/#{org}/app/#{app}/developer",
+        :path => "v1/organization/#{org}/app/#{app}/collaborators",
         :body => Heroku::Helpers.json_encode({ "email" => user }),
         :headers => {"Content-Type" => "application/json"}
+      )
+    end
+
+    def delete_collaborator(org, app, user)
+      api.request(
+        :expects => 200,
+        :method => :delete,
+        :path => "v1/organization/#{org}/app/#{app}/collaborators/#{user}"
       )
     end
 

--- a/lib/heroku/command/sharing.rb
+++ b/lib/heroku/command/sharing.rb
@@ -67,9 +67,14 @@ module Heroku::Command
         error("Usage: heroku sharing:remove EMAIL\nMust specify EMAIL to remove sharing.")
       end
       validate_arguments!
+      org_from_app!
 
       action("Removing #{email} from #{app} collaborators") do
-        api.delete_collaborator(app, email)
+        if org && org_api.get_members(org).body.map { |m| m['email'] }.include?(email)
+          org_api.delete_collaborator(org, app, email)
+        else
+          api.delete_collaborator(app, email)
+        end
       end
     end
 


### PR DESCRIPTION
- sharing:add uses "/collaborators"
- sharing:remove uses manager API when appropriate
