### PR TITLE
Extract out 'message' for `v3`

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -292,7 +292,7 @@ module Heroku
       when Array
         json.first.join(' ') # message like [['base', 'message']]
       when Hash
-        json['error'] || json['error_message']  # message like {'error' => 'message'}
+        json['error'] || json['error_message'] || json['message'] # message like {'error' => 'message'}
       else
         nil
       end


### PR DESCRIPTION
V3 errors look like:

```
{"id":"invalid_params","message":"App must be deployed before dynos can be scaled."}
```

Extract out the message field from the JSON.

https://github.com/heroku/heroku/issues/992
https://github.com/heroku/heroku/issues/987

/cc @technomancy @pedro 
