### PR TITLE
Never use the PGBACKUPS_URL from the environment

### DIFF
--- a/lib/heroku/command/pgbackups.rb
+++ b/lib/heroku/command/pgbackups.rb
@@ -205,7 +205,7 @@ module Heroku::Command
     end
 
     def pgbackup_client
-      pgbackups_url = ENV["PGBACKUPS_URL"] || config_vars["PGBACKUPS_URL"]
+      pgbackups_url = config_vars["PGBACKUPS_URL"]
       error("Please add the pgbackups addon first via:\nheroku addons:add pgbackups") unless pgbackups_url
       @pgbackup_client ||= Heroku::Client::Pgbackups.new(pgbackups_url)
     end


### PR DESCRIPTION
It's not clear from the history why this was introduced in the first
place, but the only conceivable use I can think of is testing against
a staging version of PGBackups, but that can easily be done by
actually adding the staging add-on to an app.
