### PR TITLE
Show usage in plugins:install/uninstall commands when an argument is not provided

### DIFF
--- a/lib/heroku/command/plugins.rb
+++ b/lib/heroku/command/plugins.rb
@@ -38,7 +38,10 @@ module Heroku::Command
     # Installing heroku-accounts... done
     #
     def install
-      plugin = Heroku::Plugin.new(shift_argument)
+      unless plugin_url = shift_argument
+        error("Usage: heroku plugins:install URL")
+      end
+      plugin = Heroku::Plugin.new(plugin_url)
       validate_arguments!
 
       action("Installing #{plugin.name}") do
@@ -63,7 +66,10 @@ module Heroku::Command
     # Uninstalling heroku-accounts... done
     #
     def uninstall
-      plugin = Heroku::Plugin.new(shift_argument)
+      unless plugin_name = shift_argument
+        error("Usage: heroku plugins:uninstall PLUGIN")
+      end
+      plugin = Heroku::Plugin.new(plugin_name)
       validate_arguments!
 
       action("Uninstalling #{plugin.name}") do

--- a/spec/heroku/command/plugins_spec.rb
+++ b/spec/heroku/command/plugins_spec.rb
@@ -12,53 +12,85 @@ module Heroku::Command
 
     context("install") do
 
-      before do
-        Heroku::Plugin.should_receive(:new).with('git://github.com/heroku/Plugin.git').and_return(@plugin)
-        @plugin.should_receive(:install).and_return(true)
+      context("when a plugin URL is not specified") do
+
+        it "requires a URL to be specified" do
+          stderr, stdout = execute("plugins:install")
+          stderr.should == <<-STDERR
+ !    Usage: heroku plugins:install URL
+STDERR
+          stdout.should == ""
+        end
+
       end
 
-      it "installs plugins" do
-        Heroku::Plugin.should_receive(:load_plugin).and_return(true)
-        stderr, stdout = execute("plugins:install git://github.com/heroku/Plugin.git")
-        stderr.should == ""
-        stdout.should == <<-STDOUT
+      context("when a plugin URL is specified") do
+
+        before do
+          Heroku::Plugin.should_receive(:new).with('git://github.com/heroku/Plugin.git').and_return(@plugin)
+          @plugin.should_receive(:install).and_return(true)
+        end
+
+        it "installs plugins" do
+          Heroku::Plugin.should_receive(:load_plugin).and_return(true)
+          stderr, stdout = execute("plugins:install git://github.com/heroku/Plugin.git")
+          stderr.should == ""
+          stdout.should == <<-STDOUT
 Installing Plugin... done
 STDOUT
-      end
+        end
 
-      it "does not install plugins that do not load" do
-        Heroku::Plugin.should_receive(:load_plugin).and_return(false)
-        @plugin.should_receive(:uninstall).and_return(true)
-        stderr, stdout = execute("plugins:install git://github.com/heroku/Plugin.git")
-        stderr.should == '' # normally would have error, but mocks/stubs don't allow
-        stdout.should == "Installing Plugin... " # also inaccurate, would end in ' failed'
+        it "does not install plugins that do not load" do
+          Heroku::Plugin.should_receive(:load_plugin).and_return(false)
+          @plugin.should_receive(:uninstall).and_return(true)
+          stderr, stdout = execute("plugins:install git://github.com/heroku/Plugin.git")
+          stderr.should == '' # normally would have error, but mocks/stubs don't allow
+          stdout.should == "Installing Plugin... " # also inaccurate, would end in ' failed'
+        end
+
       end
 
     end
 
     context("uninstall") do
 
-      before do
-        Heroku::Plugin.should_receive(:new).with('Plugin').and_return(@plugin)
+      context("when a plugin is not specified") do
+
+        it "requires a name to be specified" do
+          stderr, stdout = execute("plugins:uninstall")
+          stderr.should == <<-STDERR
+ !    Usage: heroku plugins:uninstall PLUGIN
+STDERR
+          stdout.should == ""
+        end
+
       end
 
-      it "uninstalls plugins" do
-        @plugin.should_receive(:uninstall).and_return(true)
-        stderr, stdout = execute("plugins:uninstall Plugin")
-        stderr.should == ""
-        stdout.should == <<-STDOUT
+      context("when a plugin is specified") do
+
+        before do
+          Heroku::Plugin.should_receive(:new).with('Plugin').and_return(@plugin)
+        end
+
+        it "uninstalls plugins" do
+          @plugin.should_receive(:uninstall).and_return(true)
+          stderr, stdout = execute("plugins:uninstall Plugin")
+          stderr.should == ""
+          stdout.should == <<-STDOUT
 Uninstalling Plugin... done
 STDOUT
-      end
+        end
 
-      it "does not uninstall plugins that do not exist" do
-        stderr, stdout = execute("plugins:uninstall Plugin")
-        stderr.should == <<-STDERR
+        it "does not uninstall plugins that do not exist" do
+          stderr, stdout = execute("plugins:uninstall Plugin")
+          stderr.should == <<-STDERR
  !    Plugin plugin not found.
 STDERR
-        stdout.should == <<-STDOUT
+          stdout.should == <<-STDOUT
 Uninstalling Plugin... failed
 STDOUT
+        end
+
       end
 
     end


### PR DESCRIPTION
Right now a TypeError (no implicit conversion of nil into String) is raised

```
 % heroku plugins:install
 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

    Error:       no implicit conversion of nil into String (TypeError)
    Backtrace:   /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/plugin.rb:159:in `basename'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/plugin.rb:159:in `guess_name'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/plugin.rb:98:in `initialize'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/command/plugins.rb:41:in `new'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/command/plugins.rb:41:in `install'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/command.rb:218:in `run'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/lib/heroku/cli.rb:28:in `start'
                 /Users/guille/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/heroku-3.2.2/bin/heroku:17:in `<top (required)>'
                 /Users/guille/.rbenv/versions/2.1.0/bin/heroku:23:in `load'
                 /Users/guille/.rbenv/versions/2.1.0/bin/heroku:23:in `<main>'

    Command:     heroku plugins:install
    Plugins:     heroku-config-versions
    Version:     heroku-gem/3.2.2 (x86_64-darwin13.0) ruby/2.1.0
```

Usually I run the commands without arguments when I want to know the correct usage.
