### PR TITLE
Introduce DNS advice for new and existing domains

### DIFF
--- a/lib/heroku/command/domains.rb
+++ b/lib/heroku/command/domains.rb
@@ -109,6 +109,7 @@ module Heroku::Command
 
       def dns_advice(app, domain)
         _app_info = app_info(app)
+        return if _app_info[:domain].nil?
         _ssl_endpoints = ssl_endpoints(app)
 
         result = []
@@ -139,11 +140,12 @@ module Heroku::Command
 
       def app_info(app)
         _info = api.get_app(app).body
-        return {
+        ret = {
               cedar: _info['stack'],
-              region: _info['region'],
-              domain: _info['domain_name']['domain']
+              region: _info['region']
             }
+        ret[:domain] = _info['domain_name']['domain'] rescue nil
+        return ret
       end
 
       def ssl_endpoints(app)

--- a/spec/heroku/command/domains_spec.rb
+++ b/spec/heroku/command/domains_spec.rb
@@ -46,6 +46,7 @@ STDOUT
       stderr.should == ""
       stdout.should == <<-STDOUT
 Adding example.com to example... done
+
 STDOUT
       api.delete_domain("example", "example.com")
     end


### PR DESCRIPTION
This commit adds some DNS help information when adding domains
or on an ad-hoc basis.  By looking at the information for an app,
the current SSL add-ons and the status of the app we can give useful
and accurate DNS information.

This has already been tested as a concept here:  https://github.com/neilmiddleton/heroku-domains-extended

Note: this does introduce dependency on the app `dominion-dns`, but this is under Heroku control.
