### PR TITLE
Add optional number to releases command

### DIFF
--- a/lib/heroku/command/releases.rb
+++ b/lib/heroku/command/releases.rb
@@ -8,6 +8,8 @@ class Heroku::Command::Releases < Heroku::Command::Base
   #
   # list releases
   #
+  # -n, --num NUM # number of releases to show, maximum 50
+  #
   #Example:
   #
   # $ heroku releases
@@ -18,10 +20,11 @@ class Heroku::Command::Releases < Heroku::Command::Base
   #
   def index
     validate_arguments!
+    release_count = options[:num].nil? ? 15 : options[:num].to_i 
 
     releases_data = api.get_releases(app).body.sort_by do |release|
       release["name"][1..-1].to_i
-    end.reverse.slice(0, 15)
+    end.reverse.slice(0, release_count)
 
     unless releases_data.empty?
       releases = releases_data.map do |release|

--- a/spec/heroku/command/releases_spec.rb
+++ b/spec/heroku/command/releases_spec.rb
@@ -37,6 +37,19 @@ v1  Config add FOO_BAR                        email@example.com  2012/01/02 12:3
 STDOUT
     end
 
+    it "should list a specified number of releases" do
+      @stderr, @stdout = execute("releases -n 5")
+      @stderr.should == ""
+      @stdout.should == <<-STDOUT
+=== example Releases
+v5  Config add SUPER_LONG_CONFIG_VAR_TO_GE..  email@example.com  2012/09/10 11:36:44 (~ 0s ago)
+v4  Config add QUX_QUUX                       email@example.com  2012/09/10 11:36:43 (~ 1s ago)
+v3  Config add BAZ_QUX                        email@example.com  2012/09/10 11:35:44 (~ 1m ago)
+v2  Config add BAR_BAZ                        email@example.com  2012/09/10 10:36:44 (~ 1h ago)
+v1  Config add FOO_BAR                        email@example.com  2012/01/02 12:34:56
+
+STDOUT
+    end
   end
 
   describe "releases:info" do


### PR DESCRIPTION
Add a `-n`, `--num` flag to the `releases` index command, to specify the number
of releases to be shown. Implements #494

There will be a separate pull request for Herokai, but this should work for everyone else. 
