### PR TITLE
fix -n releases spec

### DIFF
--- a/spec/heroku/command/releases_spec.rb
+++ b/spec/heroku/command/releases_spec.rb
@@ -16,7 +16,6 @@ describe Heroku::Command::Releases do
       api.put_config_vars("example", { 'BAZ_QUX'  => 'QUUX' })
       api.put_config_vars("example", { 'QUX_QUUX' => 'XYZZY' })
       api.put_config_vars("example", { 'SUPER_LONG_CONFIG_VAR_TO_GET_PAST_THE_TRUNCATION_LIMIT' => 'VALUE' })
-      Heroku::Command::Releases.any_instance.should_receive(:time_ago).exactly(5).times.and_return('2012/09/10 11:36:44 (~ 0s ago)', '2012/09/10 11:36:43 (~ 1s ago)', '2012/09/10 11:35:44 (~ 1m ago)', '2012/09/10 10:36:44 (~ 1h ago)', '2012/01/02 12:34:56')
     end
 
     after(:each) do
@@ -24,6 +23,7 @@ describe Heroku::Command::Releases do
     end
 
     it "should list releases" do
+      Heroku::Command::Releases.any_instance.should_receive(:time_ago).exactly(5).times.and_return('2012/09/10 11:36:44 (~ 0s ago)', '2012/09/10 11:36:43 (~ 1s ago)', '2012/09/10 11:35:44 (~ 1m ago)', '2012/09/10 10:36:44 (~ 1h ago)', '2012/01/02 12:34:56')
       @stderr, @stdout = execute("releases")
       @stderr.should == ""
       @stdout.should == <<-STDOUT
@@ -38,15 +38,14 @@ STDOUT
     end
 
     it "should list a specified number of releases" do
-      @stderr, @stdout = execute("releases -n 5")
+      Heroku::Command::Releases.any_instance.should_receive(:time_ago).exactly(3).times.and_return('2012/09/10 11:36:44 (~ 0s ago)', '2012/09/10 11:36:43 (~ 1s ago)', '2012/09/10 11:35:44 (~ 1m ago)')
+      @stderr, @stdout = execute("releases -n 3")
       @stderr.should == ""
       @stdout.should == <<-STDOUT
 === example Releases
 v5  Config add SUPER_LONG_CONFIG_VAR_TO_GE..  email@example.com  2012/09/10 11:36:44 (~ 0s ago)
 v4  Config add QUX_QUUX                       email@example.com  2012/09/10 11:36:43 (~ 1s ago)
 v3  Config add BAZ_QUX                        email@example.com  2012/09/10 11:35:44 (~ 1m ago)
-v2  Config add BAR_BAZ                        email@example.com  2012/09/10 10:36:44 (~ 1h ago)
-v1  Config add FOO_BAR                        email@example.com  2012/01/02 12:34:56
 
 STDOUT
     end


### PR DESCRIPTION
Move the `Heroku::Command::Releases.any_instance` stub to each individual spec, since we expect it different number of times. Previous version of the spec kind of worked by coincidence...
