### PR TITLE
Fix windows pg:psql

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -85,7 +85,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
       shorthand = "#{attachment.app}::#{attachment.name.sub(/^HEROKU_POSTGRESQL_/,'').gsub(/\W+/, '-')}"
       prompt_expr = "#{shorthand}%R%# "
-      prompt_flags = "--set PROMPT1='#{prompt_expr}' --set PROMPT2='#{prompt_expr}'"
+      prompt_flags = %Q(--set "PROMPT1=#{prompt_expr}" --set "PROMPT2=#{prompt_expr}")
       puts "---> Connecting to #{attachment.display_name}"
       exec "psql -U #{uri.user} -h #{uri.host} -p #{uri.port || 5432} #{prompt_flags} #{command} #{uri.path[1..-1]}"
     rescue Errno::ENOENT


### PR DESCRIPTION
The quoting style originally used to set the nice prompt for `heroku pg:psql` does not work on Windows; this changes it to a style that does (and still works on OS X and Linux).
