### PR TITLE
A mal-formed fork command can delete your application

### DIFF
--- a/lib/heroku/command/fork.rb
+++ b/lib/heroku/command/fork.rb
@@ -96,7 +96,9 @@ module Heroku::Command
       raise if e.is_a?(Heroku::Command::CommandFailed)
 
       puts "Failed to fork app #{from} to #{to}."
-      if confirm("Delete app #{to} and associated add-ons? (y/n)")
+      message = "WARNING: Potentially Destructive Action\nThis command will destroy #{to} (including all add-ons)."
+
+      if confirm_command(to, message)
         action("Deleting #{to}") do
           begin
             api.delete_app(to)

--- a/spec/heroku/command/fork_spec.rb
+++ b/spec/heroku/command/fork_spec.rb
@@ -74,13 +74,8 @@ STDOUT
       end
 
       it "deletes fork app on error, before re-raising" do
-        any_instance_of(Heroku::Command::Base) do |runner|
-          stub(runner).confirm(anything) { true }
-        end
+        stub(Heroku::Command).confirm_command.returns(true)
         stub_cisaurus.copy_slug { raise SocketError }
-        lambda do
-          execute("fork example-fork")
-        end.should raise_error(SocketError)
         api.get_apps.body.map { |app| app["name"] }.should == %w( example )
       end
     end


### PR DESCRIPTION
Today, a colleague ran the following command:

```
 heroku fork forum forum-staging
```

See the error? He forgot to include `-a` in there. As such, the toolbelt parses the command to mean "fork the forum app...to the forum app".

This fails, as you might expect, since the destination already exists.

However, as of da74e4bca94, the toolbelt _deletes_ the destination app after _any_ failure.

In other words, a fairly reasonable looking command, with a simple missing flag, can delete your application with no warning.

I'll leave the resolution ideas to those with better knowledge of the tool, but the situation as it stands feels dangerous enough that it warranted an issue. 
