### PR TITLE
Rescue nil MultiJson.decode errors

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -182,6 +182,8 @@ module Heroku
 
     def json_decode(json)
       MultiJson.decode(json)
+    rescue MultiJson::LoadError
+      nil
     end
 
     def set_buffer(enable)


### PR DESCRIPTION
Preserve the previous OkJson error handling:

![screen shot 2014-03-14 at 9 11 23 am](https://f.cloud.github.com/assets/60851/2422889/7e54577a-ab93-11e3-9346-781e507f08d2.png)

Is there something to handle on the output side?
