### PR TITLE
Alert users that we're using the API key from the environment

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -129,6 +129,7 @@ class Heroku::Auth
 
     def read_credentials
       if ENV['HEROKU_API_KEY']
+        output_with_bang("Using HEROKU_API_KEY from environment")
         ['', ENV['HEROKU_API_KEY']]
       else
         # convert legacy credentials to netrc

--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -61,6 +61,24 @@ module Heroku
       end
     end
 
+    context "API key is set via environment variable with alert" do
+      before do
+        ENV['HEROKU_API_KEY'] = "secret"
+        @cli.unstub!(:display)
+      end
+
+      it "gets credentials from environment variables in preference to credentials file" do
+        cap = capture_stdout do
+          @cli.read_credentials.should == ['', ENV['HEROKU_API_KEY']]
+        end
+        cap.should include("Using HEROKU_API_KEY from environment")
+      end
+
+      after do
+        @cli.stub!(:display)
+      end
+    end
+
     context "API key is set via environment variable" do
       before do
         ENV['HEROKU_API_KEY'] = "secret"


### PR DESCRIPTION
If you have `ENV['HEROKU_API_KEY']` set in your environment, it can be tricky sometimes, so let people know why things may be acting strange by explicitly saying "hey you have this in the env so I'm using it". See #572
