### PR TITLE
Fix pg:psql for attachable resources

### DIFF
--- a/lib/heroku/helpers/heroku_postgresql.rb
+++ b/lib/heroku/helpers/heroku_postgresql.rb
@@ -10,7 +10,7 @@ module Heroku::Helpers::HerokuPostgresql
     def initialize(raw)
       @raw = raw
       @app           = raw['app']['name']
-      @name          = raw['name']
+      @name          = raw['name'] || raw['config_var'].sub(/_URL\Z/, '')
       @config_var    = raw['config_var']
       @resource_name = raw['resource']['name']
       @url           = raw['resource']['value']


### PR DESCRIPTION
With this change, attachable resources use a shorthand in the `pg:psql` prompt based on their config var (I felt the actual haiku resource name was too unfamiliar to expose like this):

``` console
maciek@gamera:~/code/heroku$ bin/heroku pg:psql --app sushi
---> Connecting to FOLLOWER_DATABASE_URL (DATABASE_URL)
Pager usage is off.
SSL connection (cipher: DHE-RSA-AES256-SHA, bits: 256)
Type "help" for help.

sushi::FOLLOWER_DATABASE=>
```

Without this, `pg:psql` does not work for attachable resources:

``` console
maciek@gamera:~/code/heroku$ bin/heroku pg:psql --app sushi

 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

    Error:       undefined method `sub' for nil:NilClass (NoMethodError)
    Backtrace:   /home/maciek/code/heroku/lib/heroku/command/pg.rb:86:in `psql'
                 /home/maciek/code/heroku/lib/heroku/command.rb:218:in `run'
                 /home/maciek/code/heroku/lib/heroku/cli.rb:28:in `start'
                 bin/heroku:17:in `<main>'

    Command:     heroku pg:psql --app sushi
    Version:     heroku-gem/3.6.0 (x86_64-linux) ruby/1.9.3
```

The bug was introduced by me in #1022. /cc @rkst, who originally ran into this.
