### PR TITLE
Don't promote database after credentials reset

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -184,19 +184,12 @@ class Heroku::Command::Pg < Heroku::Command::Base
       action "Resetting credentials for #{attachment.display_name}" do
         hpg_client(attachment).rotate_credentials
       end
-      if attachment.primary_attachment?
-        attachment = generate_resolver.resolve(db)
-        action "Promoting #{attachment.display_name}" do
-          hpg_promote(attachment.url)
-        end
-      end
     else
       uri = URI.parse( attachment.url )
       display "Connection info string:"
       display "   \"dbname=#{uri.path[1..-1]} host=#{uri.host} port=#{uri.port || 5432} user=#{uri.user} password=#{uri.password} sslmode=require\""
       display "Connection URL:"
       display "    " + attachment.url
-
     end
   end
 

--- a/spec/heroku/command/pg_spec.rb
+++ b/spec/heroku/command/pg_spec.rb
@@ -178,7 +178,6 @@ STDERR
         stderr.should == ''
         stdout.should == <<-STDOUT
 Resetting credentials for HEROKU_POSTGRESQL_IVORY_URL (DATABASE_URL)... done
-Promoting HEROKU_POSTGRESQL_IVORY_URL (DATABASE_URL)... done
 STDOUT
       end
 
@@ -192,7 +191,6 @@ STDOUT
         stderr.should == ''
         stdout.should_not include("Promoting")
       end
-
     end
 
     context "unfollow" do


### PR DESCRIPTION
Don't promote database after credentials reset, since it's done by API now.
