### PR TITLE
Update help info for consistency

### DIFF
--- a/lib/heroku/command/keys.rb
+++ b/lib/heroku/command/keys.rb
@@ -68,7 +68,7 @@ module Heroku::Command
       end
     end
 
-    # keys:remove KEY
+    # keys:remove [KEY]
     #
     # remove a key from the current user
     #


### PR DESCRIPTION
The current help output seems to be missing square brackets around the `keys:remove` command example.

```
› heroku help keys
...

Additional commands, type "heroku help COMMAND" for more details:

  keys:add [KEY]      #  add a key for the current user
  keys:clear          #  remove all authentication keys from the current user
  keys:remove KEY     #  remove a key from the current user
  keys:search [TERM]  #  Find keys by fingerprint or contents
```

This changes fixes that by adding the square brackets around the word "KEY".
