### PR TITLE
Correctly parse app stack in both formats at creation

### DIFF
--- a/lib/heroku/command/apps.rb
+++ b/lib/heroku/command/apps.rb
@@ -253,7 +253,8 @@ class Heroku::Command::Apps < Heroku::Command::Base
         if options[:region]
           status("region is #{region_from_app(info)}")
         else
-          status("stack is #{info['stack']}")
+          stack = (info['stack'].is_a?(Hash) ? info['stack']["name"] : info['stack'])
+          status("stack is #{stack}")
         end
       end
 


### PR DESCRIPTION
Before:

```
Creating dodging-samurai-42 in organization acme-widgets-123... done, stack is {"name"=>"cedar", "id"=>"7e04461d-ec81-4bdd-8b37-b69b320a9f83"}
```

After:

```
Creating dodging-samurai-42 in organization acme-widgets-123... done, stack is cedar
```
