### PR TITLE
Explicitly load heroku/command/base because sort order is not guaranteed

### DIFF
--- a/lib/heroku/command/two_factor.rb
+++ b/lib/heroku/command/two_factor.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require "heroku/command/base"
 require "rqrcode"
 require "term/ansicolor"
 


### PR DESCRIPTION
The glob in `Heroku::Command.load` doesn't guarantee a stable sort order even though on some systems (OSX), dependencies will come through in the right order. Fix by explicitly requiring heroku/command/base from the 2FA module.

Fixes #1101.
