### PR TITLE
Fix unbound reference to "Mutex" symbol

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -1,3 +1,5 @@
+require "thread"
+
 require "heroku/client/heroku_postgresql"
 require "heroku/command/base"
 require "heroku/helpers/heroku_postgresql"


### PR DESCRIPTION
On CentOS 6, this has been reported to cause a crash.

Report and solution by Roy Hano roy.hano@clipperdata.com
