### PR TITLE
WebMock 1.11.0+ compatibility fix.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ $stdin = File.new("/dev/null")
 require "rubygems"
 
 require "excon"
-Excon.defaults[:mock] = true
 
 # ensure these are around for errors
 # as their require is generally deferred
@@ -20,6 +19,7 @@ require "webmock/rspec"
 include WebMock::API
 
 WebMock::HttpLibAdapters::ExconAdapter.disable!
+Excon.defaults[:mock] = true
 
 def api
   Heroku::API.new(:api_key => "pass", :mock => true)


### PR DESCRIPTION
Excon mocking is disable by WebMock::HttpLibAdapters::ExconAdapter.disable!
call since WebMock 1.11.0 by
https://github.com/bblimke/webmock/commit/3639da1a1c8bbc067a546dc2708c5a759de9b660
commit.

Not sure if this is the best fix, but it works for me. May be it should be improved on WebMock side instead?
