### PR TITLE
Check that `error` actually parsed before indexing on 2FA check

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -314,7 +314,10 @@ module Heroku
 
     def self.wrong_two_factor_code?(e)
       error = json_decode(e.response.body)
-      error["id"] == "invalid_two_factor_code"
+
+      # the server could have responded with XML, in which case `error` will be
+      # `nil`
+      error && error["id"] == "invalid_two_factor_code"
     end
   end
 end


### PR DESCRIPTION
If the server responded with XML here, `error` ends up as `nil`. Double check that we actually have a result before checking the identifier.

Bug encountered by @ferd. /cc @pedro 
