### PR TITLE
Fix pg:psql -c prompt quoting on windows

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -96,7 +96,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
       ENV["PGPASSWORD"] = uri.password
       ENV["PGSSLMODE"]  = 'require'
       if command = options[:command]
-        command = "-c '#{command}'"
+        command = %Q(-c "#{command}")
       end
 
       shorthand = "#{attachment.app}::#{attachment.name.sub(/^HEROKU_POSTGRESQL_/,'').gsub(/\W+/, '-')}"


### PR DESCRIPTION
`pg:psql -c` command option does not work on Windows. Becasue single quote is not allowed. 
