### PR TITLE
v3.9.7.pre2

### DIFF
--- a/lib/heroku/version.rb
+++ b/lib/heroku/version.rb
@@ -1,3 +1,3 @@
 module Heroku
-  VERSION = "3.9.7.pre"
+  VERSION = "3.9.7.pre2"
 end


### PR DESCRIPTION
last release was unsuccessful—I was on the wrong branch.

Take 2 for testing the `heroku-api` and `excon` upgrade
