### PR TITLE
Don't update manifest or update hash during beta phase.

### DIFF
--- a/dist/manifest.rake
+++ b/dist/manifest.rake
@@ -1,4 +1,6 @@
 task "manifest:update" do
+  abort "Manifest should never contain betas." if beta?
+
   tempdir do |dir|
     File.open("VERSION", "w") do |file|
       file.puts version

--- a/dist/zip.rake
+++ b/dist/zip.rake
@@ -36,5 +36,5 @@ task "zip:release" => %w( zip:build zip:sign ) do |t|
   store pkg("heroku-#{version}.zip"), "heroku-client/heroku-client-beta.zip" if beta?
   store pkg("heroku-#{version}.zip"), "heroku-client/heroku-client.zip" unless beta?
 
-  sh "heroku config:add UPDATE_HASH=#{zip_signature} -a toolbelt"
+  sh "heroku config:add UPDATE_HASH=#{zip_signature} -a toolbelt" unless beta?
 end


### PR DESCRIPTION
This will ensure that beta releases don't affect the auto-update mechanism.
