### PR TITLE
removed lazy-requiring of rest-client and heroku-api

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -13,7 +13,6 @@ class Heroku::Auth
 
     def api
       @api ||= begin
-        require("heroku-api")
         api = Heroku::API.new(default_params.merge(:api_key => password))
 
         def api.request(params, &block)
@@ -75,7 +74,6 @@ class Heroku::Auth
     end
 
     def api_key(user = get_credentials[0], password = get_credentials[1])
-      require("heroku-api")
       api = Heroku::API.new(default_params)
       api.post_login(user, password).body["api_key"]
     rescue Heroku::API::Errors::Unauthorized => e
@@ -240,22 +238,19 @@ class Heroku::Auth
     end
 
     def ask_for_and_save_credentials
-      require("heroku-api") # for the errors
-      begin
-        @credentials = ask_for_credentials
-        write_credentials
-        check
-      rescue Heroku::API::Errors::NotFound, Heroku::API::Errors::Unauthorized => e
-        delete_credentials
-        display "Authentication failed."
-        retry if retry_login?
-        exit 1
-      rescue Exception => e
-        delete_credentials
-        raise e
-      end
+      @credentials = ask_for_credentials
+      write_credentials
+      check
       check_for_associated_ssh_key unless Heroku::Command.current_command == "keys:add"
       @credentials
+    rescue Heroku::API::Errors::NotFound, Heroku::API::Errors::Unauthorized => e
+      delete_credentials
+      display "Authentication failed."
+      retry if retry_login?
+      exit 1
+    rescue Exception => e
+      delete_credentials
+      raise e
     end
 
     def check_for_associated_ssh_key

--- a/lib/heroku/cli.rb
+++ b/lib/heroku/cli.rb
@@ -4,12 +4,8 @@ load('heroku/updater.rb') # reload updater after possible inject_loadpath
 require "heroku"
 require "heroku/command"
 require "heroku/helpers"
-
-# workaround for rescue/reraise to define errors in command.rb failing in 1.8.6
-if RUBY_VERSION =~ /^1.8.6/
-  require('heroku-api')
-  require('rest_client')
-end
+require 'rest_client'
+require 'heroku-api'
 
 begin
   # attempt to load the JSON parser bundled with ruby for multi_json

--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -32,7 +32,6 @@ class Heroku::Client
   attr_accessor :host, :user, :password
 
   def initialize(user, password, host=Heroku::Auth.host)
-    require 'rest_client'
     @user = user
     @password = password
     @host = host
@@ -349,7 +348,6 @@ class Heroku::Client
     attr_accessor :attached
 
     def initialize(client, app)
-      require 'rest_client'
       @client = client
       @app = app
     end
@@ -435,7 +433,6 @@ class Heroku::Client
   # support for console sessions
   class ConsoleSession
     def initialize(id, app, client)
-      require 'rest_client'
       @id = id; @app = app; @client = client
     end
     def run(cmd)

--- a/lib/heroku/client/heroku_postgresql.rb
+++ b/lib/heroku/client/heroku_postgresql.rb
@@ -18,7 +18,6 @@ class Heroku::Client::HerokuPostgresql
   attr_reader :attachment
   def initialize(attachment)
     @attachment = attachment
-    require 'rest_client'
   end
 
   def heroku_postgresql_host

--- a/lib/heroku/client/organizations.rb
+++ b/lib/heroku/client/organizations.rb
@@ -1,4 +1,3 @@
-require 'heroku-api'
 require "heroku/client"
 
 class Heroku::Client::Organizations

--- a/lib/heroku/client/pgbackups.rb
+++ b/lib/heroku/client/pgbackups.rb
@@ -5,7 +5,6 @@ class Heroku::Client::Pgbackups
   include Heroku::Helpers
 
   def initialize(uri)
-    require 'rest_client'
     @uri = URI.parse(uri)
   end
 

--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -213,15 +213,8 @@ module Heroku
     end
 
     def self.run(cmd, arguments=[])
-      begin
-        object, method = prepare_run(cmd, arguments.dup)
-        object.send(method)
-      rescue Interrupt, StandardError, SystemExit => error
-        # load likely error classes, as they may not be loaded yet due to defered loads
-        require 'heroku-api'
-        require 'rest_client'
-        raise(error)
-      end
+      object, method = prepare_run(cmd, arguments.dup)
+      object.send(method)
     rescue Heroku::API::Errors::Unauthorized, RestClient::Unauthorized => e
       retry_login = handle_auth_error(e)
       retry if retry_login

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,6 @@ Coveralls.wear!
 
 require "excon"
 
-# ensure these are around for errors
-# as their require is generally deferred
-require "heroku-api"
-require "rest_client"
-
 require "heroku/cli"
 require "rspec"
 require "rr"


### PR DESCRIPTION
these are causing issues where we can't see the real error as it crashes trying to catch a RestClient error that hasn't been loaded. There is a technique in place to prevent that, but it's obviously not working.

Also, `heroku-api` isn't even lazy loaded. We can revisit the lazy loading later, but we need to stop these errors from being swallowed.
