### PR TITLE
require rest-client in Client

### DIFF
--- a/lib/heroku/client.rb
+++ b/lib/heroku/client.rb
@@ -6,6 +6,7 @@ require 'heroku/command'
 require 'heroku/helpers'
 require 'heroku/version'
 require 'heroku/client/ssl_endpoint'
+require 'rest_client'
 
 # A Ruby class to call the Heroku REST API.  You might use this if you want to
 # manage your Heroku apps from within a Ruby program, such as Capistrano.


### PR DESCRIPTION
Fixes #1201

RestClient is not available if you use Client directly without CLI/
