### PR TITLE
Use server-side connection reset endpoint for pg:killall

### DIFF
--- a/lib/heroku/client/heroku_postgresql.rb
+++ b/lib/heroku/client/heroku_postgresql.rb
@@ -57,6 +57,10 @@ class Heroku::Client::HerokuPostgresql
     http_put "#{resource_name}/reset"
   end
 
+  def connection_reset
+    http_post "#{resource_name}/connection_reset"
+  end
+
   def rotate_credentials
     http_post "#{resource_name}/credentials_rotation"
   end

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -268,6 +268,14 @@ class Heroku::Command::Pg < Heroku::Command::Base
   # terminates ALL connections
   #
   def killall
+    db = args.first
+    attachment = generate_resolver.resolve(db, "DATABASE_URL")
+    client = hpg_client(attachment)
+    client.connection_reset
+    display "Connections terminated"
+  rescue StandardError
+    # fall back to original mechanism if calling the reset endpoint
+    # fails
     sql = %Q(
       SELECT pg_terminate_backend(#{pid_column})
       FROM pg_stat_activity


### PR DESCRIPTION
This lets users kill all their existing connections even when they
have no remaining connections on their given database plan, preventing
a chicken-and-egg problem in some situations.

This moves a feature that we've been testing in pg-extras into the main toolbelt. The corresponding pg-extras code will be removed.
