### PR TITLE
Send all orgs-related requests to api.heroku.com

### DIFF
--- a/lib/heroku/client/organizations.rb
+++ b/lib/heroku/client/organizations.rb
@@ -230,7 +230,7 @@ class Heroku::Client::Organizations
     end
 
     def manager_url
-      ENV['HEROKU_MANAGER_URL'] || "https://manager-api.heroku.com"
+      ENV['HEROKU_MANAGER_URL'] || "https://api.heroku.com"
     end
 
   end


### PR DESCRIPTION
As part of the eventual deprecation of the Manager API component, the main API
will now start to respond to fulfill orgs-related requests.

See also heroku/api#2837.
