### PR TITLE
Replace code. with git. in .netrc setup

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -61,6 +61,10 @@ class Heroku::Auth
       ENV['HEROKU_HOST'] || default_host
     end
 
+    def subdomains
+      %w(api git)
+    end
+
     def reauthorize
       @credentials = ask_for_and_save_credentials
     end
@@ -100,8 +104,9 @@ class Heroku::Auth
         FileUtils.rm_f(legacy_credentials_path)
       end
       if netrc
-        netrc.delete("api.#{host}")
-        netrc.delete("git.#{host}")
+        subdomains.each do |sub|
+          netrc.delete("#{sub}.#{host}")
+        end
         netrc.save
       end
       @api, @client, @credentials = nil, nil
@@ -171,8 +176,9 @@ class Heroku::Auth
       unless running_on_windows?
         FileUtils.chmod(0600, netrc_path)
       end
-      netrc["api.#{host}"] = self.credentials
-      netrc["git.#{host}"] = self.credentials
+      subdomains.each do |sub|
+        netrc["#{sub}.#{host}"] = self.credentials
+      end
       netrc.save
     end
 

--- a/spec/heroku/auth_spec.rb
+++ b/spec/heroku/auth_spec.rb
@@ -178,7 +178,7 @@ module Heroku
       @cli.netrc["api.#{@cli.host}"] = ["user", api_key]
 
       expect(@cli.get_credentials).to eq(["user", api_key[0,40]])
-      %w{api git}.each do |section|
+      Auth.subdomains.each do |section|
         expect(Netrc.read(@cli.netrc_path)["#{section}.#{@cli.host}"]).to eq(["user", api_key[0,40]])
       end
     end


### PR DESCRIPTION
This replaces `code.heroku.com` with `git.heroku.com` in `.netrc` setup. 

@dickeyxxx I have manually tested this and the existing unit tests are passing, but please let me know if I'm missing something else that should be covered.

cc: @naaman @nzoschke 
