### PR TITLE
Fix debian ruby module dependency

### DIFF
--- a/dist/resources/deb/control
+++ b/dist/resources/deb/control
@@ -3,6 +3,6 @@ Version: <%= version %>
 Section: main
 Priority: standard
 Architecture: all
-Depends: ruby2.1|ruby2.0|ruby1.9.1, libopenssl-ruby2.1|libopenssl-ruby2.0|libopenssl-ruby1.9.1, libreadline-ruby2.1|libreadline-ruby2.0|libreadline-ruby1.9.1, libssl0.9.8 (>= 0.9.8k) | libssl1.0.0
+Depends: ruby2.1|ruby2.0|libopenssl-ruby1.9.1, ruby2.1|ruby2.0|libreadline-ruby1.9.1, ruby2.1|ruby2.0|ruby1.9.1, libssl0.9.8 (>= 0.9.8k) | libssl1.0.0
 Maintainer: Heroku
 Description: Client library and CLI to deploy apps on Heroku.


### PR DESCRIPTION
Remove libopenssl and libreadline dependency for ruby>1.9 This will fix #1137
