### PR TITLE
unique warnings before output

### DIFF
--- a/lib/heroku/command.rb
+++ b/lib/heroku/command.rb
@@ -99,7 +99,7 @@ module Heroku
 
     def self.display_warnings
       unless warnings.empty?
-        $stderr.puts(warnings.map {|warning| " !    #{warning}"}.join("\n"))
+        $stderr.puts(warnings.uniq.map {|warning| " !    #{warning}"}.join("\n"))
       end
     end
 


### PR DESCRIPTION
On some commands that make many API calls, you get the same warnings on each API call, and then they display in a block like this:

```
!     Some identical warning message
!     Some identical warning message
!     Some identical warning message
!     Some identical warning message
!     Some identical warning message
```

This fixes that!
