### PR TITLE
Bump Excon to 0.40.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    excon (0.39.5)
+    excon (0.40.0)
     fakefs (0.5.2)
     heroku-api (0.3.19)
       excon (~> 0.38)


### PR DESCRIPTION
This pulls in out-of-the-box support for HTTP proxies running on Unix sockets.

Here's the full change log since from 0.39.5 to 0.40.0; mostly minor test stuff and bug fixes:

```
0.40.0 10/06/2014
=================

fix support for specifying ssl_ca_path
more consistent response_block/response.body behavior for mocks
add support for proxies running on unix domain sockets

0.39.6 09/22/2014
=================

pretty print stub not found errors
```
