### PR TITLE
(Re-)bump Excon to 0.40.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    excon (0.39.5)
+    excon (0.40.0)
     fakefs (0.5.2)
     heroku-api (0.3.19)
       excon (~> 0.38)


### PR DESCRIPTION
Doh, somehow we lost the Excon bump during the Toolbelt release that came with 90bfb6dc54a67f4dc866c8abf9c3e41b57314fec. This pull bumps it back up to 0.40.0.
