### PR TITLE
Deprecate heroku-symbol plugin

### DIFF
--- a/lib/heroku/plugin.rb
+++ b/lib/heroku/plugin.rb
@@ -24,6 +24,7 @@ module Heroku
       heroku-status
       heroku-stop
       heroku-suggest
+      heroku-symbol
       heroku-two-factor
       pgbackups-automate
       pgcmd


### PR DESCRIPTION
The functionality was merged previously in
571b1c5bab511d63f5b9c689576b6f33fee874dd.
