### PR TITLE
Prompt for 2fa on stderr instead of stdout

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -211,7 +211,7 @@ class Heroku::Auth
     end
 
     def ask_for_second_factor
-      display "Two-factor code: ", false
+      $stderr.print "Two-factor code: "
       @two_factor_code = ask
       @two_factor_code = nil if @two_factor_code == ""
       @api = nil # reset it


### PR DESCRIPTION
This means that a 2fa prompt is still visible if, e.g., one is piping the result of a heroku command which requires 2fa into another command:

Before this patch:

``` console
maciek@gamera:~/code/heroku$ bin/heroku config -a db-corral | grep foo
# hangs indefinitely after the above; it does actually work if i just feed it
# my 2fa code blind, but i have to know to do that
ccccccdlnndrcidhrtgligivrvvlfetgdnkukhrrhfef 
foo:                               4
test:                              foo
maciek@gamera:~/code/heroku$
```

After this patch:

``` console
maciek@gamera:~/code/heroku$ bin/heroku config -a db-corral | grep foo
# now shows prompt before waiting for 2fa code
Two-factor code: ccccccdlnndrtrnebkkclicdbbfcrhiideekjgncetun
foo:                               4
test:                              foo
maciek@gamera:~/code/heroku$
```
