### PR TITLE
Revert "Mask 2fa inputs"

### DIFF
--- a/lib/heroku/auth.rb
+++ b/lib/heroku/auth.rb
@@ -216,26 +216,7 @@ class Heroku::Auth
 
     def ask_for_second_factor
       $stderr.print "Two-factor code: "
-      running_on_windows? ? ask : ask_for_second_factor_masked
-    end
-
-    def ask_for_second_factor_masked
-      state = `stty -g`
-      `stty raw -echo -icanon isig`
-
-      i = 0
-      code = ""
-      while c = STDIN.getc.chr
-        break if "\r" == c
-        i += 1
-        code += c
-        print i < 13 ? c : '.'
-      end
-      print "\r\n"
-
-      code
-    ensure
-      `stty #{state}`
+      ask
     end
 
     def preauth


### PR DESCRIPTION
Reverts heroku/heroku#1253 since it doesn't allow for backspaces and is a bit complex
