### PR TITLE
added can_release step to release process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,13 +12,21 @@ Dir.glob('tasks/helpers/*.rb').each { |r| import r }
 Dir.glob('tasks/*.rake').each { |r| import r }
 
 desc "release v#{version}"
-task "release" => ["build", "tgz:release", "zip:release", "manifest:update", "deb:release", "gem:release", "git:tag"] do
+task "release" => ["can_release", "build", "tgz:release", "zip:release", "manifest:update", "deb:release", "gem:release", "git:tag"] do
   puts("released v#{version}")
 end
 
 desc "build v#{version}"
 task "build" => ["tgz:build", "zip:build", "deb:build", "gem:build"] do
   puts("built v#{version}")
+end
+
+desc "check to see if v#{version} is not already released"
+task :can_release do
+  if `gem list ^heroku$ --remote` == "heroku (#{version})\n"
+    $stderr.puts "cannot release v#{version}"
+    exit(1)
+  end
 end
 
 task :default => :spec


### PR DESCRIPTION
this ensures that the CLI is not released if the released version is the
current version (the dev didn't bump the version)
