### PR TITLE
Handle nils when trying to truncate text

### DIFF
--- a/lib/heroku/helpers.rb
+++ b/lib/heroku/helpers.rb
@@ -117,6 +117,7 @@ module Heroku
     end
 
     def truncate(text, length)
+      return "" if text.nil?
       if text.size > length
         text[0, length - 2] + '..'
       else


### PR DESCRIPTION
Some releases have a nil description, and the call to truncate
that is raising
