### PR TITLE
Remove special error handler from addons

### DIFF
--- a/lib/heroku/command/addons.rb
+++ b/lib/heroku/command/addons.rb
@@ -249,14 +249,6 @@ module Heroku::Command
 
       status [ release, price ].compact.join(' ')
       { :attachment => attachment, :message => message }
-    rescue RestClient::ResourceNotFound => e
-      error Heroku::Command.extract_error(e.http_body) {
-        e.http_body =~ /^([\w\s]+ not found).?$/ ? $1 : "Resource not found"
-      }
-    rescue RestClient::Locked => ex
-      raise
-    rescue RestClient::RequestFailed => e
-      error Heroku::Command.extract_error(e.http_body)
     end
 
     def configure_addon(label, &install_or_upgrade)


### PR DESCRIPTION
These are here for historical reasons; the generic handler under `Heroku::Command.prepare_run` will do a much better job now.

More specifically this will make sure addons commands are going to follow generic auth rules, like requesting for 2fa when necessary.
