### PR TITLE
Update rubyzip dependency to 1.1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       multi_json (~> 1.10.1)
       netrc (>= 0.10.0)
       rest-client (= 1.6.7)
-      rubyzip (>= 0.9.9)
+      rubyzip (~> 1.1.6)
       zip-zip (~> 0.3)
 
 GEM

--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "launchy",        ">= 0.3.2"
   gem.add_dependency "netrc",          ">= 0.10.0"
   gem.add_dependency "rest-client",    "= 1.6.7"
-  gem.add_dependency "rubyzip",        ">= 0.9.9"
+  gem.add_dependency "rubyzip",        "~> 1.1.6"
   gem.add_dependency "zip-zip",        "~> 0.3"
   gem.add_dependency "multi_json",     "~> 1.10.1"
 end


### PR DESCRIPTION
Rubyzip's API changed at 1.0 but they've got a gem called zip-zip we can use to upgrade safely without having to update all the code immediately.
