### PR TITLE
Added tests and fixed up logic errors in checking git insecurity

### DIFF
--- a/lib/heroku/git.rb
+++ b/lib/heroku/git.rb
@@ -1,21 +1,33 @@
+require "heroku/helpers"
+
 module Heroku::Git
   extend Heroku::Helpers
 
   def self.check_git_version
     return unless running_on_windows? || running_on_a_mac?
-    v = Version.parse(git_version)
-    if v > Version.parse('1.8') && v < Version.parse('1.8.5.6')
+    if git_is_insecure(git_version)
       warn_about_insecure_git
     end
-    if v > Version.parse('1.9') && v < Version.parse('1.9.5')
-      warn_about_insecure_git
+  end
+
+  def self.git_is_insecure(version)
+    v = Version.parse(version)
+    if v < Version.parse('1.8.5.6')
+      return true
     end
-    if v > Version.parse('2.0') && v < Version.parse('2.0.5')
-      warn_about_insecure_git
+    if v >= Version.parse('1.9') && v < Version.parse('1.9.5')
+      return true
     end
-    if v > Version.parse('2.1') && v < Version.parse('2.2.1')
-      warn_about_insecure_git
+    if v >= Version.parse('2.0') && v < Version.parse('2.0.5')
+      return true
     end
+    if v >= Version.parse('2.1') && v < Version.parse('2.1.4')
+      return true
+    end
+    if v >= Version.parse('2.2') && v < Version.parse('2.2.1')
+      return true
+    end
+    return false
   end
 
   def self.warn_about_insecure_git

--- a/spec/heroku/git_spec.rb
+++ b/spec/heroku/git_spec.rb
@@ -1,0 +1,48 @@
+require "heroku/git"
+
+describe Heroku::Git do
+  # Secure versions from http://article.gmane.org/gmane.linux.kernel/1853266
+  it "determines an insecure 1.7 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('1.7')).to eq(true)
+  end
+
+  it "determines an insecure 1.8 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('1.8.5')).to eq(true)
+  end
+
+  it "determines an secure 1.8 version is secure" do
+    expect(Heroku::Git.git_is_insecure('1.8.5.6')).to eq(false)
+  end
+
+  it "determines an insecure 1.9 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('1.9.3')).to eq(true)
+  end
+
+  it "determines an secure 1.9 version is secure" do
+    expect(Heroku::Git.git_is_insecure('1.9.5')).to eq(false)
+  end
+
+  it "determines an insecure 2.0 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('2.0')).to eq(true)
+  end
+
+  it "determines an secure 2.0 version is secure" do
+    expect(Heroku::Git.git_is_insecure('2.0.5')).to eq(false)
+  end
+
+  it "determines an insecure 2.1 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('2.1')).to eq(true)
+  end
+
+  it "determines an secure 2.1 version is secure" do
+    expect(Heroku::Git.git_is_insecure('2.1.4')).to eq(false)
+  end
+
+  it "determines an insecure 2.2 version is insecure" do
+    expect(Heroku::Git.git_is_insecure('2.2')).to eq(true)
+  end
+
+  it "determines an secure 2.2 version is secure" do
+    expect(Heroku::Git.git_is_insecure('2.2.1')).to eq(false)
+  end
+end


### PR DESCRIPTION
As mentioned in #1341, we have logic errors in the `git` security logic. Since this can get very annoying to users very fast, I decided to add tests. This caught some issues that the patch #1342 didn't catch. In this PR:
- Added tests for `git` security checking
- Added edge case for when `git version` is below `1.8`
- Fixed edge cases when we are at a patch version of `0` (e.g. `2.2`/`2.2.0`)
