### PR TITLE
require the at option when scheduling backups

### DIFF
--- a/lib/heroku/command/pg_backups.rb
+++ b/lib/heroku/command/pg_backups.rb
@@ -396,7 +396,10 @@ EOF
   def schedule_backups
     db = shift_argument
     validate_arguments!
-    at = options[:at] || '04:00 UTC'
+    if !options[:at]
+      error("A time must be specified when scheduling backups")
+    end
+    at = options[:at]
     schedule_opts = parse_schedule_time(at)
 
     resolver = generate_resolver


### PR DESCRIPTION
Small UX problem whereby someone creates a schedule and then issues the same command without the at flag thinking they could view schedules.  The schedule is overwritten and set back to 4:00 UTC.

/cc @uhoh-itsmaciek @chadbailey59 

What do you guys think?
