### PR TITLE
Update rubyzip to 1.2.1 to fix security vulnerability

### DIFF
--- a/heroku.gemspec
+++ b/heroku.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "launchy",         "2.4.3"
   gem.add_dependency "netrc",           "0.10.3"
   gem.add_dependency "rest-client",     "1.6.8"
-  gem.add_dependency "rubyzip",         "1.1.7"
+  gem.add_dependency "rubyzip",         "1.2.1"
   gem.add_dependency "multi_json",      "1.11.2"
   gem.add_dependency "net-ssh-gateway", "1.2.0"
   gem.add_dependency "net-ssh",         "2.9.2" # freeze net-ssh to 2.9.2 to preserve ruby 1.9.3 support


### PR DESCRIPTION
This fixes a security vulnerability in rubyzip. https://github.com/rubyzip/rubyzip/issues/315